### PR TITLE
Jotai and Nuqs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tailwindcss/postcss": "4.1.3",
     "cross-env": "^7.0.3",
     "graphql": "^16.8.1",
+    "jotai": "2.12.3",
     "next": "15.2.3",
     "next-intl": "^4.0.2",
     "nuqs": "2.4.1",
@@ -56,5 +57,5 @@
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.1.1"
   },
-  "packageManager": "pnpm@10.8.0"
+  "packageManager": "pnpm@10.8.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       graphql:
         specifier: ^16.8.1
         version: 16.10.0
+      jotai:
+        specifier: 2.12.3
+        version: 2.12.3(@types/react@19.0.12)(react@19.0.0)
       next:
         specifier: 15.2.3
         version: 15.2.3(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4)
@@ -3478,6 +3481,18 @@ packages:
 
   jose@5.9.6:
     resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
+
+  jotai@2.12.3:
+    resolution: {integrity: sha512-DpoddSkmPGXMFtdfnoIHfueFeGP643nqYUWC6REjUcME+PG2UkAtYnLbffRDw3OURI9ZUTcRWkRGLsOvxuWMCg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -8983,6 +8998,11 @@ snapshots:
   jiti@2.4.2: {}
 
   jose@5.9.6: {}
+
+  jotai@2.12.3(@types/react@19.0.12)(react@19.0.0):
+    optionalDependencies:
+      '@types/react': 19.0.12
+      react: 19.0.0
 
   joycon@3.1.1: {}
 

--- a/src/app/(frontend)/[locale]/layout.tsx
+++ b/src/app/(frontend)/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import { NextIntlClientProvider, hasLocale } from "next-intl";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { notFound } from "next/navigation";
 import { routing } from "@/i18n/routing";
+import { Provider as JotaiProvider } from "jotai";
 
 import "@/styles/index.css";
 import { Header } from "@/containers/header";
@@ -31,8 +32,10 @@ export default async function LocaleLayout({
       <body>
         <NuqsAdapter>
           <NextIntlClientProvider>
-            <Header />
-            {children}
+            <JotaiProvider>
+              <Header />
+              {children}
+            </JotaiProvider>
           </NextIntlClientProvider>
         </NuqsAdapter>
       </body>

--- a/src/app/(frontend)/[locale]/parsers.ts
+++ b/src/app/(frontend)/[locale]/parsers.ts
@@ -1,0 +1,3 @@
+import { parseAsArrayOf, parseAsFloat } from "nuqs";
+
+export const bboxParser = parseAsArrayOf(parseAsFloat, ",");

--- a/src/app/(frontend)/[locale]/store.ts
+++ b/src/app/(frontend)/[locale]/store.ts
@@ -1,0 +1,10 @@
+import { useQueryState } from "nuqs";
+import { bboxParser } from "./parsers";
+import { atom } from "jotai";
+
+// MAP
+export const useSyncBbox = () => {
+  return useQueryState("bbox", bboxParser);
+};
+
+export const tmpBboxAtom = atom<number[]>();


### PR DESCRIPTION
This pull request includes several changes to dependencies and the integration of the `jotai` state management library. The most important changes include updates to the `package.json` and `pnpm-lock.yaml` files, as well as modifications in the frontend code to incorporate `jotai`.

### Dependency Updates:
* Added `jotai` version `2.12.3` to `package.json` and updated the `pnpm` version to `10.8.1` [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R27) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L59-R60).
* Included `jotai` with its dependencies in the `pnpm-lock.yaml` file [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR35-R37) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3485-R3496) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9002-R9006).

### Frontend Integration:
* Imported `JotaiProvider` in `src/app/(frontend)/[locale]/layout.tsx` and wrapped the `Header` and `children` components with `JotaiProvider` ([src/app/(frontend)/[locale]/layout.tsxR5](diffhunk://#diff-50fddd4db8e93c18c55bf6807495c80ae359c6550c1b2ff4bffffd053997106eR5), [src/app/(frontend)/[locale]/layout.tsxR35-R38](diffhunk://#diff-50fddd4db8e93c18c55bf6807495c80ae359c6550c1b2ff4bffffd053997106eR35-R38)).

### New Parsers and State Management:
* Added new parsers in `src/app/(frontend)/[locale]/parsers.ts` for handling array and float parsing ([src/app/(frontend)/[locale]/parsers.tsR1-R3](diffhunk://#diff-be560319ff92576f64530710e64d0a9c9084d57e0b52540bc32f76dd778f96bfR1-R3)).
* Created a new store in `src/app/(frontend)/[locale]/store.ts` to sync bounding box state and define a temporary bounding box atom using `jotai` ([src/app/(frontend)/[locale]/store.tsR1-R10](diffhunk://#diff-d76a489126cbc6e734fd3fc7c60d58cc01f1dba4e0b490c235beb3d7d0fe1259R1-R10)).