### PR TITLE
Basemap selector

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -14,10 +14,19 @@ const nextConfig = {
   // Add the packages in transpilePackages
   transpilePackages: ["@t3-oss/env-nextjs", "@t3-oss/env-core", "three"],
 
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "api.mapbox.com",
+      },
+    ],
+  },
+
   // turbopack: {
   //   rules: {
   //     "*.glsl": {
-  //       loaders: ["raw-loader"],
+  //       loaders: [path.resolve(__dirname, "src/lib/glsl-loader.js")],
   //       as: "*.js",
   //     },
   //   },

--- a/app/src/app/(frontend)/[locale]/(app)/parsers.ts
+++ b/app/src/app/(frontend)/[locale]/(app)/parsers.ts
@@ -1,7 +1,13 @@
-import { parseAsArrayOf, parseAsFloat, parseAsString } from "nuqs";
+import { parseAsArrayOf, parseAsFloat, parseAsString, parseAsStringLiteral } from "nuqs";
+
+import { BASEMAPS } from "@/components/map/controls/settings/basemap";
 
 export const bboxParser = parseAsArrayOf(parseAsFloat, ",").withDefault([
   -109.52, -15.27, 87.93, 73.4,
 ]);
+
+export const basemapParser = parseAsStringLiteral(
+  Object.values(BASEMAPS).map((b) => b.id),
+).withDefault("default");
 
 export const locationParser = parseAsString.withDefault("Worldwide");

--- a/app/src/app/(frontend)/[locale]/(app)/store.ts
+++ b/app/src/app/(frontend)/[locale]/(app)/store.ts
@@ -1,14 +1,17 @@
 import { atom } from "jotai";
 import { useQueryState } from "nuqs";
 
-import { bboxParser, locationParser } from "./parsers";
+import { basemapParser, bboxParser, locationParser } from "./parsers";
 
 // MAP
 export const useSyncBbox = () => {
   return useQueryState("bbox", bboxParser);
 };
-
 export const tmpBboxAtom = atom<number[]>();
+
+export const useSyncBasemap = () => {
+  return useQueryState("basemap", basemapParser);
+};
 
 // LOCATIONS
 export const useSyncLocation = () => {

--- a/app/src/components/map/controls/settings/basemap.tsx
+++ b/app/src/components/map/controls/settings/basemap.tsx
@@ -1,0 +1,54 @@
+import Image from "next/image";
+
+import { cn } from "@/lib/utils";
+
+import { env } from "@/env";
+
+export const BASEMAPS = {
+  default: {
+    id: "default",
+    name: "Default",
+    mapStyle: "mapbox://styles/wetlands-vizzuality/cmaoz7mg901l701qoaj2a6v0h",
+    image: `https://api.mapbox.com/styles/v1/wetlands-vizzuality/cmaoz7mg901l701qoaj2a6v0h/static/7.1924,4.7851,3.85,0/200x200?access_token=${env.NEXT_PUBLIC_MAPBOX_TOKEN}&attribution=false&logo=false`,
+  },
+  satellite: {
+    id: "satellite",
+    name: "Satellite",
+    mapStyle: "mapbox://styles/wetlands-vizzuality/cmbkp0emy00pj01sm9ggihl1q",
+    image: `https://api.mapbox.com/styles/v1/wetlands-vizzuality/cmbkp0emy00pj01sm9ggihl1q/static/7.1924,4.7851,3.85,0/200x200?access_token=${env.NEXT_PUBLIC_MAPBOX_TOKEN}&attribution=false&logo=false`,
+  },
+} as const;
+
+export type BasemapControlProps = {
+  basemap: keyof typeof BASEMAPS;
+  onBasemapChange: (basemapId: keyof typeof BASEMAPS) => void;
+};
+
+export const BasemapControl = ({ basemap, onBasemapChange }: BasemapControlProps) => {
+  return (
+    <div className="flex flex-col overflow-hidden">
+      {Object.values(BASEMAPS).map((b) => (
+        <button
+          key={b.id}
+          type="button"
+          className={cn(`flex items-center gap-2 py-2 pr-4 pl-2`, {
+            "hover:bg-gray-300": basemap !== b.id,
+            "bg-blue-500/25": basemap === b.id,
+          })}
+          onClick={() => onBasemapChange(b.id)}
+        >
+          <Image
+            loading="lazy"
+            src={b.image}
+            alt={b.name}
+            width={200}
+            height={200}
+            className="mb-1 h-10 w-10 rounded-full object-cover"
+          />
+
+          {b.name}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/app/src/components/map/controls/settings/index.tsx
+++ b/app/src/components/map/controls/settings/index.tsx
@@ -58,7 +58,7 @@ export const SettingsControl: FC<PropsWithChildren<SettingsControlProps>> = ({
             </TooltipPortal>
           )}
 
-          <PopoverContent side="left" align="start">
+          <PopoverContent side="left" align="start" className="w-auto overflow-hidden p-0">
             {children}
           </PopoverContent>
         </Tooltip>

--- a/app/src/containers/map/index.tsx
+++ b/app/src/containers/map/index.tsx
@@ -1,25 +1,31 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { useAtom } from "jotai";
 import Map, { LngLatBoundsLike, MapProps, useMap } from "react-map-gl/mapbox";
 import { useDebounceCallback } from "usehooks-ts";
 
-import { tmpBboxAtom, useSyncBbox } from "@/app/(frontend)/[locale]/(app)/store";
+import { tmpBboxAtom, useSyncBasemap, useSyncBbox } from "@/app/(frontend)/[locale]/(app)/store";
 
 import Controls from "@/components/map/controls";
 import LayersControl from "@/components/map/controls/layers";
 import SettingsControl from "@/components/map/controls/settings";
+import { BasemapControl, BASEMAPS } from "@/components/map/controls/settings/basemap";
 import ZoomControl from "@/components/map/controls/zoom";
 
 import { env } from "@/env";
 
 export const MapContainer = (props: MapProps) => {
   const [bbox, setBbox] = useSyncBbox();
+  const [basemap, setBasemap] = useSyncBasemap();
   const [tmpBbox, setTmpBbox] = useAtom(tmpBboxAtom);
 
   const { exploreMap } = useMap();
+
+  const MAP_STYLE = useMemo(() => {
+    return BASEMAPS[basemap].mapStyle;
+  }, [basemap]);
 
   const handleMove = () => {
     if (exploreMap) {
@@ -73,7 +79,7 @@ export const MapContainer = (props: MapProps) => {
           },
         }}
         style={{ width: "100%", height: "100%" }}
-        mapStyle="mapbox://styles/wetlands-vizzuality/cmaoz7mg901l701qoaj2a6v0h"
+        mapStyle={MAP_STYLE}
         minZoom={2}
         onMove={handleMovedDebounced}
         {...props}
@@ -86,9 +92,7 @@ export const MapContainer = (props: MapProps) => {
             </div>
           </LayersControl>
           <SettingsControl>
-            <div className="flex flex-col space-y-0.5">
-              <span>Basemap</span>
-            </div>
+            <BasemapControl basemap={basemap} onBasemapChange={setBasemap} />
           </SettingsControl>
         </Controls>
       </Map>


### PR DESCRIPTION
This pull request introduces a new "basemap" feature to the map component, allowing users to select different map styles. It includes updates to the configuration, parsers, state management, and UI components to support this functionality. Additionally, minor UI improvements were made to the settings control.

### Basemap Feature Implementation:

* **Basemap Configuration**:
  - Added `BASEMAPS` constant in `app/src/components/map/controls/settings/basemap.tsx` to define available basemaps, including their IDs, names, styles, and preview images.
  - Updated `next.config.ts` to allow loading images from the Mapbox API by specifying remote patterns in the `images` configuration.

* **State Management**:
  - Added `basemapParser` in `app/src/app/(frontend)/[locale]/(app)/parsers.ts` to parse and validate basemap values from query strings. ([app/src/app/(frontend)/[locale]/(app)/parsers.tsL1-R12](diffhunk://#diff-2bfc4b52faad423dc5702e6419524030c26a76377543396a88aec09fc8b85649L1-R12))
  - Introduced `useSyncBasemap` state hook in `app/src/app/(frontend)/[locale]/(app)/store.ts` to synchronize the selected basemap with the application state. ([app/src/app/(frontend)/[locale]/(app)/store.tsL4-R15](diffhunk://#diff-6b0c983bba198c096e76a996d7297b7b45a72e4d50cbc687706f1ada17bf8aeaL4-R15))

* **Map Component Updates**:
  - Modified `MapContainer` in `app/src/containers/map/index.tsx` to dynamically update the map style based on the selected basemap using the `MAP_STYLE` memoized value. [[1]](diffhunk://#diff-1acfa250ff17aa59cb3446da9e089b270b72d391750e5acfedf9ee32287bab26L3-R29) [[2]](diffhunk://#diff-1acfa250ff17aa59cb3446da9e089b270b72d391750e5acfedf9ee32287bab26L76-R82)
  - Replaced the static basemap selector UI in `SettingsControl` with the new `BasemapControl` component for interactive basemap selection.

### UI Improvements:

* **Settings Control**:
  - Enhanced `PopoverContent` styling in `app/src/components/map/controls/settings/index.tsx` to improve layout and overflow handling.