### PR TITLE
Toggle: persist url query params

### DIFF
--- a/app/src/app/(frontend)/[locale]/(app)/layout.tsx
+++ b/app/src/app/(frontend)/[locale]/(app)/layout.tsx
@@ -37,8 +37,8 @@ export default async function AppLayout({ children }: { children: React.ReactNod
           <div className="pointer-events-none fixed top-4 right-4 z-10 flex items-center gap-2">
             <Suspense>
               <Language />
+              <Toggle />
             </Suspense>
-            <Toggle />
           </div>
 
           <Suspense>

--- a/app/src/app/(frontend)/[locale]/(app)/store.ts
+++ b/app/src/app/(frontend)/[locale]/(app)/store.ts
@@ -1,5 +1,5 @@
 import { atom } from "jotai";
-import { useQueryState } from "nuqs";
+import { createSerializer, useQueryState } from "nuqs";
 
 import {
   basemapParser,
@@ -55,3 +55,25 @@ export const storiesAtom = atom<{
   search: "",
   enabled: false,
 });
+
+// SERIALIZERS
+export const persistedSearchParamsSerializer = createSerializer({
+  bbox: bboxParser,
+  basemap: basemapParser,
+  insight: insightParser,
+  location: locationParser,
+});
+
+export const useGetSearchParams = () => {
+  const [bbox] = useSyncBbox();
+  const [basemap] = useSyncBasemap();
+  const [insight] = useSyncInsight();
+  const [location] = useSyncLocation();
+
+  return persistedSearchParamsSerializer({
+    bbox,
+    basemap,
+    insight,
+    location,
+  });
+};

--- a/app/src/containers/toogle/index.tsx
+++ b/app/src/containers/toogle/index.tsx
@@ -5,10 +5,13 @@ import { LuBookOpen, LuLightbulb } from "react-icons/lu";
 
 import { cn } from "@/lib/utils";
 
+import { useGetSearchParams } from "@/app/(frontend)/[locale]/(app)/store";
+
 import { Link, usePathname } from "@/i18n/navigation";
 
 export const Toggle = () => {
   const pathname = usePathname();
+  const searchParams = useGetSearchParams();
 
   const t = useTranslations("header");
 
@@ -16,7 +19,7 @@ export const Toggle = () => {
     <ul className="bg-background inline-flex items-center gap-1 rounded-4xl p-0.5">
       <li>
         <Link
-          href="/"
+          href={`/${searchParams ? `${searchParams}` : ""}`}
           className={cn(
             "pointer-events-auto flex items-center gap-2 rounded-4xl px-4 py-2 text-sm",
             pathname !== "/" && "hover:underline",
@@ -28,7 +31,7 @@ export const Toggle = () => {
       </li>
       <li>
         <Link
-          href="/stories"
+          href={`/stories${searchParams ? `${searchParams}` : ""}`}
           className={cn(
             "pointer-events-auto flex items-center gap-2 rounded-4xl px-4 py-2 text-sm",
             pathname !== "/stories" && "hover:underline",


### PR DESCRIPTION
This pull request introduces changes to improve state management and enhance URL handling in the frontend application. The most important updates include the addition of serializers for persisting search parameters, integration of these serializers into the `Toggle` component for dynamic URL generation, and minor adjustments to the layout structure.

### State Management Enhancements:
* `app/src/app/(frontend)/[locale]/(app)/store.ts`: Added `persistedSearchParamsSerializer` using `createSerializer` to serialize and persist search parameters (`bbox`, `basemap`, `insight`, `location`). Also introduced a `useGetSearchParams` hook for retrieving and formatting these parameters. ([app/src/app/(frontend)/[locale]/(app)/store.tsR58-R79](diffhunk://#diff-6b0c983bba198c096e76a996d7297b7b45a72e4d50cbc687706f1ada17bf8aeaR58-R79))
* `app/src/app/(frontend)/[locale]/(app)/store.ts`: Updated imports to include `createSerializer` from `nuqs`. ([app/src/app/(frontend)/[locale]/(app)/store.tsL2-R2](diffhunk://#diff-6b0c983bba198c096e76a996d7297b7b45a72e4d50cbc687706f1ada17bf8aeaL2-R2))

### URL Handling Improvements:
* [`app/src/containers/toogle/index.tsx`](diffhunk://#diff-705212cd9851b1e90d4bfae6f5f7fbd01f704f12eb6c7f881aec65de5086d62aR8-R22): Integrated `useGetSearchParams` into the `Toggle` component to dynamically append serialized search parameters to `href` attributes for navigation links. [[1]](diffhunk://#diff-705212cd9851b1e90d4bfae6f5f7fbd01f704f12eb6c7f881aec65de5086d62aR8-R22) [[2]](diffhunk://#diff-705212cd9851b1e90d4bfae6f5f7fbd01f704f12eb6c7f881aec65de5086d62aL31-R34)

### Layout Adjustments:
* `app/src/app/(frontend)/[locale]/(app)/layout.tsx`: Fixed the placement of the `Suspense` wrapper around the `Language` component to ensure proper rendering. ([app/src/app/(frontend)/[locale]/(app)/layout.tsxL40-R41](diffhunk://#diff-a3ea66c98835250894e5e9692526c0df89ac0ea50c972bd70216d99d54e2536eL40-R41))