### PR TITLE
Create COGS processing functionality

### DIFF
--- a/data-processing/scripts/create_cogs.py
+++ b/data-processing/scripts/create_cogs.py
@@ -2,22 +2,40 @@
 Script to create Cloud Optimized GeoTIFFs (COGs) from TIFF files.
 """
 
-from pathlib import Path
+from rich.console import Console
 
+from processing.config import OUTPUT_COG_DIR, RAW_DATA_DIR
 from processing.converters.cogs import convert_tif_to_cog
 from processing.data.storage.gcs import remove_file_from_local_storage, upload_file_to_gcs
-from rich.console import Console
 
 console = Console()
 
-DATA_PATH = Path("data/processed")
-COGS_PATH = Path("data/processed/cogs")
-
 DATASETS = {
-    "wetlands": {
-        "source": DATA_PATH / "IUCN_Classified_Sahel_2019-2023.tif",
-        "output": COGS_PATH / "IUCN_Classified_Sahel_2019-2023.tif",
+    "Wetlands (by type)": {
+        "source": RAW_DATA_DIR
+        / "Classification_Test_V1-0_Iv_Ow_Classes_BurnMF_BurnSM_BurnGMW_Mask_Clip.tif",
+        "output": OUTPUT_COG_DIR / "wetlands_by_type_cog.tif",
         "resampling": "nearest",
+        "nodata_value": 0,
+        "upload_to_gcs": False,
+    },
+    "Wetlands (by Ramsar)": {
+        "source": RAW_DATA_DIR / "tropwet_sahel_basic_ramsar_typology_v1.tif",
+        "output": OUTPUT_COG_DIR / "wetlands_by_ramsar_cog.tif",
+        "resampling": "nearest",
+        "nodata_value": 0,
+        "upload_to_gcs": False,
+    },
+    "Peatlands": {
+        "source": RAW_DATA_DIR / "peatlands_sahel_CLIPPED.tif",
+        "output": OUTPUT_COG_DIR / "peatlands_cog.tif",
+        "resampling": "nearest",
+        "upload_to_gcs": False,
+    },
+    "Irrecoverable Carbon": {
+        "source": RAW_DATA_DIR / "irrecoverable_carbon_CLIPPED.tif",
+        "output": OUTPUT_COG_DIR / "irrecoverable_carbon_cog.tif",
+        "resampling": "bilinear",
         "upload_to_gcs": False,
     },
 }
@@ -27,7 +45,7 @@ def main():
     """Main function to create COGs from TIFF files."""
     console.print("🚀 Starting COG creation workflow...")
 
-    COGS_PATH.mkdir(parents=True, exist_ok=True)
+    OUTPUT_COG_DIR.mkdir(parents=True, exist_ok=True)
 
     for name, paths in DATASETS.items():
         console.print(f"\nProcessing {name} dataset...")
@@ -40,7 +58,12 @@ def main():
             continue
 
         console.print(f"🌍 Converting {source_path} to {output_path}...")
-        convert_tif_to_cog(source_path, output_path, resampling)
+        if paths.get("nodata_value") is None:
+            convert_tif_to_cog(source_path, output_path, resampling)
+        else:
+            convert_tif_to_cog(
+                source_path, output_path, resampling, nodata_value=paths.get("nodata_value")
+            )
 
         if paths.get("upload_to_gcs", True):
             console.print(f"📤 Uploading {output_path} to GCS...")

--- a/data-processing/src/processing/config.py
+++ b/data-processing/src/processing/config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 # Directory paths
 RAW_DATA_DIR = Path("data/raw/")
 OUTPUT_DIR = Path("data/processed/")
+OUTPUT_COG_DIR = OUTPUT_DIR / "cogs"
 
 # File paths
 SAHEL_BOUNDARY_FILE = RAW_DATA_DIR / "sahel_boundary.gpkg"

--- a/data-processing/src/processing/converters/cogs.py
+++ b/data-processing/src/processing/converters/cogs.py
@@ -3,12 +3,18 @@ Module for converting data to COGS format.
 """
 
 from pathlib import Path
+from typing import Optional
 
 from rio_cogeo.cogeo import cog_translate
 from rio_cogeo.profiles import cog_profiles
 
 
-def convert_tif_to_cog(input_file: Path, output_file: Path, resampling: str = "average") -> None:
+def convert_tif_to_cog(
+    input_file: Path,
+    output_file: Path,
+    resampling: str = "average",
+    nodata_value: Optional[float] = None,
+) -> None:
     """
     Convert a TIFF file to a Cloud Optimized GeoTIFF (COG) format.
 
@@ -22,6 +28,9 @@ def convert_tif_to_cog(input_file: Path, output_file: Path, resampling: str = "a
         Resampling method for overviews. Default is "average".
         Options include: "nearest", "bilinear", "cubic", "cubic_spline",
         "lanczos", "average", "mode", "gauss", "max", "min", "med", "q1", "q3".
+    nodata_value : float, optional
+        Value to be treated as nodata. If None, uses the existing nodata value
+        from the input file.
     """
     # Get the LZW COG profile with web optimization
     cog_profile = cog_profiles.get("lzw")
@@ -42,5 +51,6 @@ def convert_tif_to_cog(input_file: Path, output_file: Path, resampling: str = "a
         cog_profile,
         overview_resampling=resampling,
         web_optimized=True,
+        nodata=nodata_value,
         quiet=False,
     )


### PR DESCRIPTION
This pull request updates the workflow for creating Cloud Optimized GeoTIFFs (COGs) from TIFF files to support new datasets and adds more flexibility to the conversion process. The main changes include adding support for a configurable nodata value, introducing new dataset definitions, and updating directory configuration for outputs.

**Dataset & Workflow Updates:**

* Added new datasets to the `DATASETS` dictionary in `create_cogs.py`, including "Wetlands (by type)", "Wetlands (by Ramsar)", "Peatlands", and "Irrecoverable Carbon", each with custom source/output paths, resampling methods, and nodata values.

**COG Conversion Flexibility:**

* Enhanced the `convert_tif_to_cog` function in `cogs.py` to accept an optional `nodata_value` argument, allowing explicit specification of nodata values during conversion. 
* Updated the COG creation workflow to pass the nodata value from the dataset configuration when present, ensuring correct handling of nodata pixels for each dataset.