### PR TITLE
Locations: Search reset

### DIFF
--- a/app/src/components/ui/button.tsx
+++ b/app/src/components/ui/button.tsx
@@ -22,6 +22,7 @@ const buttonVariants = cva(
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        xs: "h-6 rounded-md gap-1 px-2 text-2xs",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
       },

--- a/app/src/containers/header/index.tsx
+++ b/app/src/containers/header/index.tsx
@@ -40,7 +40,7 @@ export const Header = ({
 
       <div
         className={cn("animate-in fade-in slide-in-from-top-10 relative z-20 w-full duration-500", {
-          "rounded-4xl bg-white/10 backdrop-blur-lg": blur,
+          "bg-background/75 rounded-4xl backdrop-blur-lg": blur,
         })}
       >
         {children}

--- a/app/src/containers/locations/search.tsx
+++ b/app/src/containers/locations/search.tsx
@@ -6,7 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { CommandInput } from "cmdk";
 import { useAtom, useSetAtom } from "jotai";
 import { LucideXCircle } from "lucide-react";
-import { useLocale } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { LuMapPin, LuSearch } from "react-icons/lu";
 
 import { cn } from "@/lib/utils";
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 import { locationsAtom, tmpBboxAtom, useSyncLocation } from "@/app/(frontend)/[locale]/(app)/store";
 
 import { GLOBAL_SAHEL_BBOX } from "@/components/map/controls/constants";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 import API from "@/services/api";
 
@@ -21,6 +22,7 @@ export const LocationsSearch = () => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const locale = useLocale();
+  const t = useTranslations();
 
   const [location, setLocation] = useSyncLocation();
   const [locations, setLocations] = useAtom(locationsAtom);
@@ -68,8 +70,15 @@ export const LocationsSearch = () => {
       search: undefined,
       enabled: false,
     });
+  };
+
+  const handleReset = () => {
     setLocation(null);
     setTmpBbox(GLOBAL_SAHEL_BBOX);
+    setLocations({
+      search: undefined,
+      enabled: false,
+    });
   };
 
   useEffect(() => {
@@ -130,6 +139,26 @@ export const LocationsSearch = () => {
         >
           <LucideXCircle className="h-6 w-6 text-current" />
         </button>
+      )}
+
+      {!locations.enabled && locationsIdData && locationsIdData?.type !== "global" && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={handleReset}
+              className={cn(
+                "text-foreground animate-in fade-in absolute top-3 right-3 flex size-10 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors duration-150",
+                "hover:text-accent",
+              )}
+            >
+              <LucideXCircle className="h-6 w-6 text-current" />
+            </button>
+          </TooltipTrigger>
+
+          <TooltipContent side="right" align="center">
+            {t("common.reset")}
+          </TooltipContent>
+        </Tooltip>
       )}
     </div>
   );

--- a/app/src/i18n/messages/en.json
+++ b/app/src/i18n/messages/en.json
@@ -129,5 +129,8 @@
       "title": "Playground | Wetlands",
       "description": "A place to play with the wetlands data."
     }
+  },
+  "common": {
+    "reset": "Reset"
   }
 }

--- a/app/src/i18n/messages/es.json
+++ b/app/src/i18n/messages/es.json
@@ -129,5 +129,8 @@
       "title": "Zona de juegos | Wetlands",
       "description": "Un lugar para jugar con los datos de las zonas húmedas."
     }
+  },
+  "common": {
+    "reset": "Restablecer"
   }
 }


### PR DESCRIPTION
This pull request introduces improvements to the location search UI and enhances the overall user experience. The main changes include adding a reset button with tooltip support, updating translations, and refining UI components for better consistency.

**User Interface Improvements**

* Added a new extra small (`xs`) size option to the `buttonVariants` utility in `button.tsx` for more flexible button sizing.
* Updated the header background style to use `bg-background/75` instead of a hardcoded color for improved theme consistency.

**Location Search Enhancements**

* Introduced a reset button in the `LocationsSearch` component that appears under specific conditions, allowing users to easily reset their location filter. The button includes a tooltip with a localized label. [[1]](diffhunk://#diff-547c0f9f6623ab4f79bbdb97d326792d408eca7dc8e6a9e00f09e073260f4198R143-R162) [[2]](diffhunk://#diff-547c0f9f6623ab4f79bbdb97d326792d408eca7dc8e6a9e00f09e073260f4198R73-R81)
* Refactored imports and logic in `LocationsSearch` to use the `useTranslations` hook and the new tooltip components.

**Translation Updates**

* Added a new `common.reset` key to both English and Spanish translation files for the reset button tooltip. [[1]](diffhunk://#diff-238d1440f73a4ba48b44fba7a59ada8f20cbb2cf49cf300a4e1a5c981bcc9d66R132-R134) [[2]](diffhunk://#diff-a00bbd012427694775fdd12330b4abe29dd37c9f7ac510bf5362290b4ed514cbR132-R134)