### PR TITLE
fe: add link to contact page for action button

### DIFF
--- a/app/src/containers/home/footer/index.tsx
+++ b/app/src/containers/home/footer/index.tsx
@@ -17,8 +17,8 @@ const Footer: FC = () => {
           <h2 className="text-3xl font-normal whitespace-pre-line">
             {t("title.prefix")} <span className="block">{t("title.highlight")}</span>
           </h2>
-          <Button variant="outline" className="rounded-full" size="lg">
-            {t("button")}
+          <Button variant="outline" className="rounded-full" size="lg" asChild>
+            <Link href="/contact">{t("button")}</Link>
           </Button>
         </div>
         <p className="max-w-md">{t("description")}</p>


### PR DESCRIPTION
## Add Navigation to Footer Contact Button

#$# Overview

Makes the footer contact button functional by adding navigation to the contact page. Previously, the button was static and non-interactive.

### Changes

- Button now navigates users to the contact page when clicked

## Breaking Changes

None

- Related issue:  #138 