### PR TITLE
change text main buttons landing page

### DIFF
--- a/app/src/i18n/messages/en.json
+++ b/app/src/i18n/messages/en.json
@@ -26,15 +26,15 @@
       "kicker": "Discover wetlands",
       "title": "The dynamic ecosystems where water meets land.",
       "description": "Ranging from mangroves and peatlands to rivers, lakes, floodplains, and coasts. Though they <strong>cover only about 6% of Earth's surface</strong>, but their impact is immense. Wetlands are indispensable for climate stability, biodiversity, and human livelihoods.",
-      "discover-button": "Discover wetlands",
-      "explore-button": "Explore data",
+      "discover-button": "Discover wetlands values",
+      "explore-button": "Explore wetland maps",
       "circle": "Discover the landscape"
     },
     "navigation": {
       "about": "About",
       "faq": "FAQ’s",
       "contact": "Contact",
-      "explore-data": "Explore data"
+      "explore-data": "Explore wetland maps"
     },
     "climate-resilience": {
       "kicker": "climate resilience",

--- a/app/src/i18n/messages/fr.json
+++ b/app/src/i18n/messages/fr.json
@@ -26,15 +26,15 @@
       "kicker": "Discover wetlands",
       "title": "The dynamic ecosystems where water meets land.",
       "description": "Ranging from mangroves and peatlands to rivers, lakes, floodplains, and coasts. Though they <strong>cover only about 6% of Earth's surface</strong>, but their impact is immense. Wetlands are indispensable for climate stability, biodiversity, and human livelihoods.",
-      "discover-button": "Discover wetlands",
-      "explore-button": "Explore data",
+      "discover-button": "Discover wetlands values",
+      "explore-button": "Explore wetland maps",
       "circle": "Discover the landscape"
     },
     "navigation": {
       "about": "About",
       "faq": "FAQ’s",
       "contact": "Contact",
-      "explore-data": "Explore data"
+      "explore-data": "Explore wetland maps"
     },
     "climate-resilience": {
       "kicker": "climate resilience",


### PR DESCRIPTION
## Update Landing Page Button Text

### Overview
Updates the main button text on the landing page to be more descriptive and specific about the content users will discover.

### Changes
- Changed "Discover wetlands" button to "Discover wetlands values"
- Changed "Explore data" button to "Explore wetland maps" (in both hero section and navigation menu)

Related issue: #144