### PR TITLE
feat: add mailing list signup button to contact page

### DIFF
--- a/app/src/containers/contact/index.tsx
+++ b/app/src/containers/contact/index.tsx
@@ -2,8 +2,13 @@
 import { FC } from "react";
 
 import { useTranslations } from "next-intl";
+import { LuExternalLink } from "react-icons/lu";
 
 import ContactForm from "@/containers/contact/form";
+
+import { Button } from "@/components/ui/button";
+
+const MAILING_LIST_URL = "https://eepurl.com/jyA0qs";
 
 const Contact: FC = () => {
   const t = useTranslations("contact");
@@ -19,6 +24,15 @@ const Contact: FC = () => {
             {t("header.title")}
           </h1>
           <p className="w-1/2 max-w-2xl text-lg font-normal">{t("header.description")}</p>
+          <div className="mt-6 flex flex-col items-start gap-4">
+            <p>{t("mailing-list.title")}</p>
+            <a href={MAILING_LIST_URL} target="_blank" rel="noopener noreferrer">
+              <Button className="rounded-full leading-5 font-normal" size="lg" variant="outline">
+                {t("mailing-list.button")}
+                <LuExternalLink />
+              </Button>
+            </a>
+          </div>
         </header>
       </section>
       <section className="flex-1 pl-10">

--- a/app/src/i18n/messages/en.json
+++ b/app/src/i18n/messages/en.json
@@ -150,6 +150,10 @@
         "description": "Your message has been sent."
       },
       "button": "Send message"
+    },
+    "mailing-list": {
+      "title": "Stay updated on wetlands news",
+      "button": "Join our mailing list"
     }
   },
   "landscapes": {

--- a/app/src/i18n/messages/es.json
+++ b/app/src/i18n/messages/es.json
@@ -150,6 +150,10 @@
         "description": "Your message has been sent."
       },
       "button": "Send message"
+    },
+    "mailing-list": {
+      "title": "Mantente al día sobre las novedades de humedales",
+      "button": "Únete a nuestra lista de correo"
     }
   },
   "landscapes": {

--- a/app/src/i18n/messages/fr.json
+++ b/app/src/i18n/messages/fr.json
@@ -150,6 +150,10 @@
         "description": "Votre message a été envoyé."
       },
       "button": "Envoyer le message"
+    },
+    "mailing-list": {
+      "title": "Restez informé des actualités sur les zones humides",
+      "button": "Rejoindre notre liste de diffusion"
     }
   },
   "landscapes": {


### PR DESCRIPTION
## Summary
- Adds a mailing list signup CTA inside the contact page header, linking to the Mailchimp form at https://eepurl.com/jyA0qs
- Button opens in a new tab with `rel="noopener noreferrer"` for security
- Translated text for all three locales (en, es, fr)

Closes #164

## Test plan
- [x] Visit `/en/contact`, `/es/contact`, `/fr/contact` and verify the mailing list text and button render correctly
- [x] Click the button and verify it opens `https://eepurl.com/jyA0qs` in a new tab
- [x] Verify translations display correctly in each locale