### PR TITLE
chore: rename 'Explore wetland maps' to 'Explore wetland atlas'

### DIFF
--- a/app/src/i18n/messages/en.json
+++ b/app/src/i18n/messages/en.json
@@ -27,14 +27,14 @@
       "title": "The dynamic ecosystems where water meets land.",
       "description": "Ranging from mangroves and peatlands to rivers, lakes, floodplains, and coasts. Though they <strong>cover only about 6% of Earth's surface</strong>, but their impact is immense. Wetlands are indispensable for climate stability, biodiversity, and human livelihoods.",
       "discover-button": "Discover wetlands values",
-      "explore-button": "Explore wetland atlas",
+      "explore-button": "Explore Wetland Atlas",
       "circle": "Discover the landscape"
     },
     "navigation": {
       "about": "About",
       "faq": "FAQ’s",
       "contact": "Contact",
-      "explore-data": "Explore wetland atlas"
+      "explore-data": "Explore Wetland Atlas"
     },
     "climate-resilience": {
       "kicker": "climate resilience",


### PR DESCRIPTION
## Summary
- Renames "Explore wetland maps" to "Explore wetland atlas" in the English locale
- Applies to both the homepage hero button and the navigation link

Closes #144

## Test plan
- [x] Pre-commit hook passed (check-types, lint, tests)
- [x] Verify hero button text reads "Explore wetland atlas"
- [x] Verify navigation link text reads "Explore wetland atlas"