### PR TITLE
feat: inherit bounding box from previous step in landscape map editor

### DIFF
--- a/app/src/cms/fields/map/field.tsx
+++ b/app/src/cms/fields/map/field.tsx
@@ -36,7 +36,7 @@ export const MapFieldComponent: JSONFieldServerComponent = async ({
         </aside>
 
         <div className="relative flex w-2/3 grow flex-col overflow-hidden bg-[#326E82]">
-          <MapfieldMap layers={layers.docs} />
+          <MapfieldMap layers={layers.docs} path={path} />
         </div>
       </section>
     </>

--- a/app/src/cms/fields/map/map.tsx
+++ b/app/src/cms/fields/map/map.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 
-import { useField, useCollapsible } from "@payloadcms/ui";
+import { useField, useCollapsible, useForm } from "@payloadcms/ui";
 
 import Map, {
   Layer,
@@ -25,22 +25,40 @@ import ZoomControl from "@/components/map/controls/zoom";
 import { env } from "@/env";
 import { Landscape, Layer as iLayer } from "@/payload-types";
 
-export const MapfieldMap = ({ layers }: { layers: iLayer[] }) => {
+export const MapfieldMap = ({ layers, path }: { layers: iLayer[]; path: string }) => {
   return (
     <MapProvider>
-      <MapfieldMapInner layers={layers} />
+      <MapfieldMapInner layers={layers} path={path} />
     </MapProvider>
   );
 };
 
-export const MapfieldMapInner = ({ layers }: { layers: iLayer[] }) => {
+export const MapfieldMapInner = ({ layers, path }: { layers: iLayer[]; path: string }) => {
   const [loaded, setLoaded] = useState(false);
   const { value, setValue } = useField<NonNullable<Landscape["steps"]>[number]["map"]>();
+  const { getDataByPath } = useForm();
   const { isCollapsed, isWithinCollapsible } = useCollapsible();
   // We use a debounced value to render the map only after the collapsible state has stabilized
   const [collapsed] = useDebounceValue(isCollapsed, 500);
 
   const { stepMap } = useMap();
+
+  const initialBbox = useMemo(() => {
+    if (value?.bbox) return value.bbox as LngLatBoundsLike;
+
+    const match = path.match(/^steps\.(\d+)\.map$/);
+    if (!match) return undefined;
+
+    const currentIndex = parseInt(match[1], 10);
+    for (let i = currentIndex - 1; i >= 0; i--) {
+      const prevMap = getDataByPath<NonNullable<Landscape["steps"]>[number]["map"]>(
+        `steps.${i}.map`,
+      );
+      if (prevMap?.bbox) return prevMap.bbox as LngLatBoundsLike;
+    }
+
+    return undefined;
+  }, [value?.bbox, path, getDataByPath]);
 
   const MAP_STYLE = useMemo(() => {
     return BASEMAPS[value?.basemap ?? "default"].mapStyle;
@@ -87,7 +105,7 @@ export const MapfieldMapInner = ({ layers }: { layers: iLayer[] }) => {
       id="stepMap"
       mapboxAccessToken={env.NEXT_PUBLIC_MAPBOX_TOKEN}
       initialViewState={{
-        ...(value?.bbox && { bounds: value?.bbox as LngLatBoundsLike }),
+        ...(initialBbox && { bounds: initialBbox }),
         fitBoundsOptions: {
           padding: {
             top: 50,


### PR DESCRIPTION
## Summary

Closes #137

- When adding a new map step in the landscape CMS editor, the map now initializes at the previous step's bounding box instead of the default world view
- Computes `initialBbox` via `useMemo` + `useForm().getDataByPath`, walking backwards through previous steps to find the nearest bbox
- Once the map settles, the existing `onMove` handler persists the inherited bbox to the form field

## Test plan

- [x] Create a new Landscape, add a map step, set a specific bbox by panning/zooming
- [x] Add a second map step — verify it inherits the bbox from step 1
- [x] Add a chart step, then a map step — verify the map step inherits the bbox from step 1 (skipping the chart)
- [x] Add a map step as the first step — verify it has no pre-populated bbox
- [x] Verify that after inheritance, the user can freely modify the bbox