### PR TITLE
feat: enable video embed in all landscape steps (#127)

### DIFF
--- a/app/scripts/seed.ts
+++ b/app/scripts/seed.ts
@@ -490,8 +490,7 @@ const seedLandscapes = async (db: DB, tx: TX): Promise<void> => {
   const now = new Date().toISOString();
 
   for (const row of rows) {
-    const { id, name, cover, description, category, location, published, embeddedVideo, steps } =
-      row;
+    const { id, name, cover, description, category, location, published, steps } = row;
 
     // Optional: Check that category exists (foreign key)
     const categoryExists = await tx.query.categories.findFirst({
@@ -515,8 +514,6 @@ const seedLandscapes = async (db: DB, tx: TX): Promise<void> => {
         cover: cover ?? null,
         geoLocation: locationPoint ? sql`ST_GeomFromText(${locationPoint}, 4326)` : null,
         published: published ?? false,
-        embedded_video_type: embeddedVideo?.type,
-        embedded_video_source: embeddedVideo?.source,
         createdAt: now,
         updatedAt: now,
       })
@@ -527,8 +524,6 @@ const seedLandscapes = async (db: DB, tx: TX): Promise<void> => {
           cover: cover ?? null,
           geoLocation: locationPoint ? sql`ST_GeomFromText(${locationPoint}, 4326)` : null,
           published: published ?? false,
-          embedded_video_type: embeddedVideo?.type,
-          embedded_video_source: embeddedVideo?.source,
           updatedAt: now,
         },
       });
@@ -541,14 +536,12 @@ const seedLandscapes = async (db: DB, tx: TX): Promise<void> => {
         _parentID: id,
         name,
         description,
-        embedded_video_title: embeddedVideo?.title ?? null,
       })
       .onConflictDoUpdate({
         target: [landscapesLocales._locale, landscapesLocales._parentID],
         set: {
           name,
           description,
-          embedded_video_title: embeddedVideo?.title ?? null,
         },
       });
 

--- a/app/src/cms/blocks/video-embed.ts
+++ b/app/src/cms/blocks/video-embed.ts
@@ -1,0 +1,38 @@
+import { Block } from "payload";
+
+export const VideoEmbedBlock: Block = {
+  slug: "videoEmbed",
+  labels: {
+    singular: "Video Embed",
+    plural: "Video Embeds",
+  },
+  fields: [
+    {
+      type: "select",
+      name: "type",
+      label: "Video Type",
+      required: true,
+      defaultValue: "youtube",
+      options: [{ label: "YouTube", value: "youtube" }],
+    },
+    {
+      name: "source",
+      type: "text",
+      label: "Video URL",
+      required: true,
+      admin: {
+        description: "YouTube embed URL (e.g., https://www.youtube.com/embed/VIDEO_ID)",
+      },
+    },
+    {
+      name: "title",
+      type: "text",
+      label: "Video Title",
+      required: true,
+      localized: true,
+      admin: {
+        description: "Accessible title for the video iframe",
+      },
+    },
+  ],
+};

--- a/app/src/cms/collections/Landscapes.ts
+++ b/app/src/cms/collections/Landscapes.ts
@@ -1,9 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { revalidatePath } from "next/cache";
 
 import { CollectionConfig } from "payload";
 
 import {
+  BlocksFeature,
   BoldFeature,
   FixedToolbarFeature,
   HeadingFeature,
@@ -17,27 +17,12 @@ import {
 } from "@payloadcms/richtext-lexical";
 
 import { PublicAccessControl } from "@/cms/access/public";
+import { VideoEmbedBlock } from "@/cms/blocks/video-embed";
 import { ChartField } from "@/cms/fields/chart-field";
 import { MapField } from "@/cms/fields/map";
 import { SlugIDField } from "@/cms/fields/slug";
 import { landscapesReadLocationCriteriaExtension } from "@/cms/hooks/landscapes-read-location-criteria-extension";
 import { env } from "@/env";
-
-const validateEmbeddedVideoSource = (value: any, opts: any) => {
-  const { embedded_video } = opts.data;
-  if (embedded_video.type && !embedded_video.source) {
-    return "Embedded video source is required.";
-  }
-  return true;
-};
-
-const validateEmbeddedVideoTitle = (value: any, opts: any) => {
-  const { embedded_video } = opts.data;
-  if (embedded_video.type && !embedded_video.title) {
-    return "Embedded video title is required.";
-  }
-  return true;
-};
 
 export const Landscapes: CollectionConfig = {
   slug: "landscapes",
@@ -78,32 +63,6 @@ export const Landscapes: CollectionConfig = {
       type: "upload",
       relationTo: "media",
       localized: false,
-    },
-    {
-      type: "group",
-      name: "embedded_video",
-      label: "Embedded video",
-      required: false,
-
-      fields: [
-        {
-          type: "select",
-          name: "type",
-          options: [{ label: "Youtube", value: "youtube" }],
-        },
-        {
-          name: "source",
-          type: "text",
-          localized: false,
-          validate: validateEmbeddedVideoSource,
-        },
-        {
-          name: "title",
-          type: "text",
-          localized: true,
-          validate: validateEmbeddedVideoTitle,
-        },
-      ],
     },
     {
       name: "category",
@@ -169,6 +128,9 @@ export const Landscapes: CollectionConfig = {
               ItalicFeature(),
               LinkFeature(),
               UploadFeature(),
+              BlocksFeature({
+                blocks: [VideoEmbedBlock],
+              }),
             ],
           }),
         },

--- a/app/src/components/embedded-video/index.tsx
+++ b/app/src/components/embedded-video/index.tsx
@@ -1,14 +1,34 @@
 import { FC } from "react";
 
+function toYouTubeEmbedUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    // Already an embed URL
+    if (parsed.pathname.startsWith("/embed/")) return url;
+    // https://www.youtube.com/watch?v=VIDEO_ID
+    if (parsed.hostname.includes("youtube.com") && parsed.searchParams.has("v")) {
+      return `https://www.youtube.com/embed/${parsed.searchParams.get("v")}`;
+    }
+    // https://youtu.be/VIDEO_ID
+    if (parsed.hostname === "youtu.be" && parsed.pathname.length > 1) {
+      return `https://www.youtube.com/embed${parsed.pathname}`;
+    }
+  } catch {
+    // Invalid URL, return as-is
+  }
+  return url;
+}
+
 interface EmbeddedVideoProps {
   src?: string | null;
   title?: string | null;
 }
 const EmbeddedVideo: FC<EmbeddedVideoProps> = ({ src, title }) => {
+  const embedSrc = src ? toYouTubeEmbedUrl(src) : undefined;
   return (
     <iframe
       className="aspect-video w-full"
-      src={src || undefined}
+      src={embedSrc}
       title={title || undefined}
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
       referrerPolicy="strict-origin-when-cross-origin"

--- a/app/src/components/ui/lexical/index.tsx
+++ b/app/src/components/ui/lexical/index.tsx
@@ -2,12 +2,14 @@ import React, { HTMLAttributes, JSX } from "react";
 
 import {
   DefaultNodeTypes,
+  SerializedBlockNode,
   SerializedInlineBlockNode,
   SerializedListNode,
 } from "@payloadcms/richtext-lexical";
 import type { SerializedEditorState } from "@payloadcms/richtext-lexical/lexical";
 import { JSXConverters, JSXConvertersFunction, RichText } from "@payloadcms/richtext-lexical/react";
 
+import EmbeddedVideo from "@/components/embedded-video";
 import { NumberBlock } from "@/components/ui/lexical/blocks/number-block";
 import { VariableBlock } from "@/components/ui/lexical/blocks/variable-block";
 import { CustomUploadComponent } from "@/components/ui/lexical/converters/upload";
@@ -68,7 +70,18 @@ export const Lexical = (props: LexicalProps) => {
         ? (base as (a: unknown) => React.ReactNode)(args)
         : (base as React.ReactNode);
     },
-    blocks: {},
+    blocks: {
+      videoEmbed: ({
+        node,
+      }: {
+        node: SerializedBlockNode<{
+          blockType: "videoEmbed";
+          type: string;
+          source: string;
+          title: string;
+        }>;
+      }) => <EmbeddedVideo src={node.fields.source} title={node.fields.title} />,
+    },
     inlineBlocks: {
       number: ({
         node,

--- a/app/src/containers/landscapes/[id]/article.tsx
+++ b/app/src/containers/landscapes/[id]/article.tsx
@@ -3,13 +3,11 @@ import { RichText } from "@payloadcms/richtext-lexical/react";
 import { LandscapeImage } from "@/containers/landscapes/[id]/image";
 import { LandscapeSteps } from "@/containers/landscapes/[id]/steps";
 
-import EmbeddedVideo from "@/components/embedded-video";
 import { ScrollArrow } from "@/components/ui/scroll-arrow";
 
 import { Landscape } from "@/payload-types";
 
 export const LandscapesIdArticle = (props: Landscape) => {
-  const embeddedVideo = props["embedded_video"]?.source ? props["embedded_video"] : null;
   const imageUrl = typeof props.cover === "object" ? props.cover?.url : undefined;
 
   return (
@@ -22,11 +20,7 @@ export const LandscapesIdArticle = (props: Landscape) => {
           className="animate-in fade-in slide-in-from-top-10 my-4 text-lg text-gray-400"
           data={props.description}
         />
-        {embeddedVideo ? (
-          <EmbeddedVideo src={embeddedVideo.source} title={embeddedVideo.title} />
-        ) : imageUrl ? (
-          <LandscapeImage imageUrl={imageUrl} />
-        ) : null}
+        {imageUrl ? <LandscapeImage imageUrl={imageUrl} /> : null}
         <ScrollArrow />
       </div>
 

--- a/app/src/payload-types.ts
+++ b/app/src/payload-types.ts
@@ -351,11 +351,6 @@ export interface Landscape {
     [k: string]: unknown;
   };
   cover?: (number | null) | Media;
-  embedded_video?: {
-    type?: 'youtube' | null;
-    source?: string | null;
-    title?: string | null;
-  };
   category: string | Category;
   /**
    * @minItems 2
@@ -722,13 +717,6 @@ export interface LandscapesSelect<T extends boolean = true> {
   name?: T;
   description?: T;
   cover?: T;
-  embedded_video?:
-    | T
-    | {
-        type?: T;
-        source?: T;
-        title?: T;
-      };
   category?: T;
   geoLocation?: T;
   location?: T;


### PR DESCRIPTION
## Summary

- Replace dedicated intro-only `embedded_video` group field with a `VideoEmbed` Lexical block available in **all** landscape steps
- Add YouTube URL auto-conversion (watch/share/embed URLs all work)
- Clean up seed script references to removed field

Closes #127

## Test plan

- [x] Open CMS admin, edit a landscape, add a Video Embed block to a step's sidebar
- [x] Paste a `youtube.com/watch?v=...` URL and verify it renders correctly
- [x] Paste a `youtu.be/...` short URL and verify it renders correctly
- [x] Verify the intro section no longer shows the old embedded video field
- [x] Verify existing landscapes without video blocks render normally