### PR TITLE
feat: distance-based map transition speed

### DIFF
--- a/app/src/containers/landscapes/[id]/map/fit-bounds.tsx
+++ b/app/src/containers/landscapes/[id]/map/fit-bounds.tsx
@@ -7,8 +7,8 @@ import { stepAtom } from "@/app/(frontend)/[locale]/(landscapes)/landscapes/[id]
 
 import { Landscape } from "@/payload-types";
 
-const MIN_DURATION = 1000;
-const MAX_DURATION = 3000;
+const MIN_DURATION = 2000;
+const MAX_DURATION = 4000;
 
 const getBboxCenter = (bbox: LngLatBoundsLike): [number, number] => {
   const b = bbox as [number, number, number, number];


### PR DESCRIPTION
## Summary
- Calculate Euclidean distance between consecutive step bbox centers to scale `flyTo` duration
- Short hops (nearby steps) use ~1000ms minimum duration
- Long jumps (cross-globe) scale linearly up to 3000ms maximum
- Track previous bbox via `useRef` to compute step-to-step deltas
- First step always uses minimum duration (no previous bbox to compare)

Closes #147

## Test plan
- [x] Navigate between landscape steps that are geographically close — transition should be quick (~2s)
- [x] Navigate between steps far apart — transition should be slower (up to 4s)
- [x] First step load should use minimum duration (2s)
- [x] Bearing and pitch changes still apply correctly during transition
- [x] No visual glitches when rapidly switching between steps