### PR TITLE
feat: move indicator labels from indicator-data to indicators

### DIFF
--- a/app/src/migrations/20260327_100000_move_labels_to_indicators.ts
+++ b/app/src/migrations/20260327_100000_move_labels_to_indicators.ts
@@ -9,9 +9,9 @@ export async function up({ db }: MigrateUpArgs): Promise<void> {
     --    Each indicator has the same labels regardless of location, so we take
     --    one row per (indicator, locale) pair using DISTINCT ON.
     INSERT INTO "indicators_locales" ("_locale", "_parent_id", "labels")
-    SELECT DISTINCT ON (id.indicator, idl."_locale")
+    SELECT DISTINCT ON (id."indicator_id", idl."_locale")
       idl."_locale",
-      id.indicator,
+      id."indicator_id",
       idl.labels
     FROM "indicator_data_locales" idl
     JOIN "indicator_data" id ON id.id = idl."_parent_id"


### PR DESCRIPTION
## Summary

- Moves the `labels` field from `IndicatorDatas` to `Indicators` so labels are defined once per indicator rather than duplicated across every indicator-data row
- Migration adds `labels` column to `indicators_locales` and copies existing data from `indicator_data_locales`
- `indicator_data_locales` is intentionally **not dropped** in this PR (expand phase) — the contract phase (drop) follows in a separate PR once this is confirmed live

## Migration notes

This migration is backward-compatible: `indicator_data_locales` is kept intact so the previously deployed code continues to work if a build fails after migration runs.

## Test plan

- [ ] Verify migration runs cleanly on staging
- [ ] Confirm labels are accessible on the `Indicator` collection in the CMS admin
- [ ] Confirm indicator-data rows no longer expose a `labels` field
- [ ] Verify existing label data was copied correctly for all locales