### PR TITLE
feat: drop indicator_data_locales table (contract phase)

### DIFF
--- a/app/src/migrations/20260327_120000_drop_indicator_data_locales.ts
+++ b/app/src/migrations/20260327_120000_drop_indicator_data_locales.ts
@@ -1,0 +1,26 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    DROP TABLE "indicator_data_locales" CASCADE;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    CREATE TABLE "indicator_data_locales" (
+      "labels" jsonb NOT NULL DEFAULT '{}',
+      "id" serial PRIMARY KEY NOT NULL,
+      "_locale" "_locales" NOT NULL,
+      "_parent_id" varchar NOT NULL
+    );
+
+    ALTER TABLE "indicator_data_locales"
+      ADD CONSTRAINT "indicator_data_locales_parent_id_fk"
+      FOREIGN KEY ("_parent_id") REFERENCES "public"."indicator_data"("id")
+      ON DELETE cascade ON UPDATE no action;
+
+    CREATE UNIQUE INDEX "indicator_data_locales_locale_parent_id_unique"
+      ON "indicator_data_locales" USING btree ("_locale", "_parent_id");
+  `)
+}

--- a/app/src/migrations/index.ts
+++ b/app/src/migrations/index.ts
@@ -28,6 +28,7 @@ import * as migration_20251020_073201_add_published_to_categories from './202510
 import * as migration_20251120_174722_add_locations_relationship_to_landscapes from './20251120_174722_add_locations_relationship_to_landscapes';
 import * as migration_20260219_062652_add_unit_to_indicators from './20260219_062652_add_unit_to_indicators';
 import * as migration_20260327_100000_move_labels_to_indicators from './20260327_100000_move_labels_to_indicators';
+import * as migration_20260327_120000_drop_indicator_data_locales from './20260327_120000_drop_indicator_data_locales';
 
 export const migrations = [
   {
@@ -179,5 +180,10 @@ export const migrations = [
     up: migration_20260327_100000_move_labels_to_indicators.up,
     down: migration_20260327_100000_move_labels_to_indicators.down,
     name: '20260327_100000_move_labels_to_indicators',
+  },
+  {
+    up: migration_20260327_120000_drop_indicator_data_locales.up,
+    down: migration_20260327_120000_drop_indicator_data_locales.down,
+    name: '20260327_120000_drop_indicator_data_locales',
   },
 ];


### PR DESCRIPTION
## Summary

Contract phase of the expand-contract migration started in #185/#186.

Now that the new code is live and reading `labels` from `indicators_locales`, the old `indicator_data_locales` table is no longer used and can be safely dropped.

## Test plan

- [ ] Verify migration runs cleanly on staging
- [ ] Confirm no code references `indicator_data_locales` after merge