### PR TITLE
fix: make nginx redirect environment-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,61 @@ Run `pdm install` inside titiler folder after the activate command f you need to
 This project uses git LFS for the `app-initial-data` seeding files.
 In case you cannot see the contents of a data file, use `git lfs pull`.
 [https://git-lfs.com](https://git-lfs.com)
+
+## Deployment
+
+### Architecture
+
+The app runs as a single Heroku Docker container managed by **supervisord** with three services:
+
+- **nginx** (port `$PORT`) — reverse proxy, redirects `*.herokuapp.com` to the canonical domain
+- **Next.js app** (port 3000) — frontend + Payload CMS backend
+- **Tiler** (port 8000) — Python uvicorn tile server, proxied under `/tiler`
+
+### Environments
+
+| | Staging | Production |
+|---|---|---|
+| Branch | `staging` | `main` |
+| Heroku app | `wetlands-gap-map-staging` | `wetland-gap-map-prod` |
+| Canonical URL | `https://gaps-staging.wetlands.org` | `https://www.wetlandatlas.org` |
+
+### How deployment works
+
+Pushes to `main` or `staging` trigger the GitHub Actions workflow (`.github/workflows/deploy.yml`), which:
+
+1. **Fetches config vars from Heroku** via the Heroku API — these are the source of truth for all environment variables
+2. **Builds the Docker image** passing the Heroku config vars as `--build-arg` values (this bakes `NEXT_PUBLIC_*` vars into the Next.js bundle)
+3. **Pushes the image** to the Heroku Container Registry
+4. **Releases** the new image on Heroku
+
+At container startup (`app-start.sh`), `envsubst` templates the nginx and supervisord configs with runtime values (`$PORT`, `$NEXT_PUBLIC_API_URL`).
+
+### GitHub secrets and variables
+
+Only **two** GitHub-level values are used by the deploy workflow:
+
+| Name | Type | Purpose |
+|---|---|---|
+| `HEROKU_API_KEY` | Secret | Authenticates with the Heroku API to fetch config vars and deploy |
+| `HEROKU_APP_NAME` | Variable | Identifies which Heroku app to fetch config from and deploy to |
+
+**All other environment variables** (database URI, API keys, public URLs, etc.) are stored as **Heroku config vars** and fetched at build time. Any other GitHub variables you see are unused by the deploy workflow.
+
+### Heroku config vars
+
+These are configured on each Heroku app and serve as the single source of truth:
+
+| Variable | Purpose | Build-time | Runtime |
+|---|---|---|---|
+| `DATABASE_URI` | PostgreSQL connection string | Yes (migrations) | Yes |
+| `PAYLOAD_SECRET` | Payload CMS secret | Yes | Yes |
+| `PREVIEW_SECRET` | Draft preview secret | Yes | Yes |
+| `NEXT_PUBLIC_API_URL` | Canonical app URL (e.g. `https://www.wetlandatlas.org`) | Yes (baked into JS) | Yes (nginx redirect target, supervisord) |
+| `NEXT_PUBLIC_MAPBOX_TOKEN` | Mapbox GL token | Yes (baked into JS) | No |
+| `NEXT_PUBLIC_TILER_URL` | Tiler endpoint URL | Yes (baked into JS) | No |
+| `GCS_PROJECT_ID` | Google Cloud Storage project | Yes | Yes |
+| `GCS_BUCKET_NAME` | GCS bucket name | Yes | Yes |
+| `GCS_SERVICE_ACCOUNT_KEY` | GCS service account credentials | Yes | Yes |
+
+> **Important:** `NEXT_PUBLIC_*` variables are embedded in the JavaScript bundle at build time. Changing them on Heroku requires a **redeploy** to take effect.

--- a/app-start.sh
+++ b/app-start.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 export PORT=${PORT:-80}
-envsubst '\$PORT' < /etc/nginx/nginx.template.conf > /etc/nginx/nginx.conf
-
 export NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost}
+
+envsubst '\$PORT \$NEXT_PUBLIC_API_URL' < /etc/nginx/nginx.template.conf > /etc/nginx/nginx.conf
 envsubst '\$NEXT_PUBLIC_API_URL' < /etc/supervisord.template.conf > /etc/supervisord.conf
 
 cat /etc/nginx/nginx.conf

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -34,15 +34,14 @@ http {
     server {
         listen $PORT;
         listen [::]:$PORT;
-        server_name ~^wetlands-gap-map-staging-.*\.herokuapp\.com$;
-        return 301 https://gaps-staging.wetlands.org$request_uri;
+        server_name ~\.herokuapp\.com$;
+        return 301 $NEXT_PUBLIC_API_URL$request_uri;
     }
 
-    # ───────── 2) App server for gaps-staging.wetlands.org ─────────
+    # ───────── 2) App server for the canonical domain ─────────
     server {
-        listen $PORT;
-        listen [::]:$PORT;
-        server_name gaps-staging.wetlands.org www.gaps-staging.wetlands.org;
+        listen $PORT default_server;
+        listen [::]:$PORT default_server;
 
         client_max_body_size 50m;
 


### PR DESCRIPTION
## Summary
- **Fix nginx redirect:** The nginx config had a hardcoded 301 redirect to `gaps-staging.wetlands.org`, causing production `*.herokuapp.com` requests to fall through to the staging redirect. Now uses `$NEXT_PUBLIC_API_URL` via `envsubst` so each environment redirects to its own canonical domain.
- **Add deployment docs to README:** Documents the architecture, environments, CI/CD pipeline, which GitHub secrets/variables are actually used, and the full list of Heroku config vars with build-time vs runtime distinction.

## Test plan
- [ ] Deploy to staging and verify `*.herokuapp.com` URL redirects to `https://gaps-staging.wetlands.org`
- [ ] Deploy to production and verify `*.herokuapp.com` URL redirects to `https://www.wetlandatlas.org`
- [ ] Verify canonical domain URLs serve the app directly without redirect loops