### PR TITLE
fix: Remove the S from wetlands logo to wetland

### DIFF
--- a/app/src/containers/logo/index.tsx
+++ b/app/src/containers/logo/index.tsx
@@ -1,7 +1,7 @@
 export const LogoText = () => (
   <div className={"ps-4"}>
     <h3 className={"font-black"}>
-      Wetlands <span className={"font-normal"}>Atlas</span>
+      Wetland <span className={"font-normal"}>Atlas</span>
     </h3>
   </div>
 );


### PR DESCRIPTION
## Summary

Remove an S from Wetland landing page logo
- In the landing page changed from "Wetlands Atlas" to plain text displaying "Wetland Atlas"

<img width="1606" height="374" alt="image" src="https://github.com/user-attachments/assets/9b7b7fba-4690-4317-9133-14a18592898a" />


## Test plan

- [ ] Verify that in the landing page you can only see the text "Wetland Atlas"