### PR TITLE
feat: Changed to new logo in the landing page

### DIFF
--- a/app/src/containers/home/navbar/index.tsx
+++ b/app/src/containers/home/navbar/index.tsx
@@ -8,7 +8,7 @@ import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 
 import { Language } from "@/containers/language";
-import { LogoText } from "@/containers/logo";
+import { Logo } from "@/containers/logo";
 
 import { Button } from "@/components/ui/button";
 
@@ -41,7 +41,7 @@ const Navbar: FC = () => {
           className="relative z-10 block items-center space-x-2"
           aria-label={t("header.title")}
         >
-          <LogoText />
+          <Logo />
         </Link>
         <nav>
           <ul className="flex items-center gap-4">

--- a/app/src/containers/logo/index.tsx
+++ b/app/src/containers/logo/index.tsx
@@ -1,8 +1,10 @@
-export const LogoText = () => (
-  <div className={"ps-4"}>
-    <h3 className={"font-black"}>
-      Wetland <span className={"font-normal"}>Atlas</span>
-    </h3>
+import Image from "next/image";
+
+import wetlandsLogo from "@/../public/about/wetlands.svg";
+
+export const Logo = () => (
+  <div>
+    <Image src={wetlandsLogo} alt="Wetland Atlas" className={"h-12"} />
   </div>
 );
 


### PR DESCRIPTION
## Summary

Changed to the new logo in the landing page

<img width="1458" height="678" alt="image" src="https://github.com/user-attachments/assets/f65394ee-949b-4502-b9a1-b94f4da60c86" />


## Test plan

- [ ] Verify that in the landing page you can only see the new colored logo of Wetlands International