### PR TITLE
Update types statistics

### DIFF
--- a/app-initial-data/indicator-data.json
+++ b/app-initial-data/indicator-data.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb8ddfcdfeb1525793e55396b7bac4bb010dc402e4f12001fd188625b9dd4a94
-size 8675027
+oid sha256:e8306b47f77c57936b7ca47256e03217dfa9bca91df6b81f427336ada5ae854d
+size 10573313

--- a/app-initial-data/indicator-data.json
+++ b/app-initial-data/indicator-data.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8306b47f77c57936b7ca47256e03217dfa9bca91df6b81f427336ada5ae854d
-size 10573313
+oid sha256:494638c113447f4b043c74b28f1d5cb7b4762e1bccfbe27e643191418e15be88
+size 11126935

--- a/data-processing/notebooks/07a_DEPRECATED_wetlands_inventory_data.ipynb
+++ b/data-processing/notebooks/07a_DEPRECATED_wetlands_inventory_data.ipynb
@@ -1,0 +1,1752 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b3aae68c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import geopandas as gpd\n",
+    "import json\n",
+    "import os\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c516c608",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gcs_path = \"https://storage.googleapis.com/wetlands-gap-map/original_data\"\n",
+    "analysis_data_folder = 'Analysis_Data_insight_Wetlands_Inventory'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2b06ac31",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total locations: 2068\n",
+      "Total Sahel locations: 1\n",
+      "Total country locations: 26\n",
+      "Total WDPA locations: 2024\n",
+      "Total basin locations: 17\n"
+     ]
+    }
+   ],
+   "source": [
+    "locations = gpd.read_file(f'{gcs_path}/locations_simplified.geojson')\n",
+    "locations_sahel = locations[locations['type'] == 'global']\n",
+    "locations_countries = locations[locations['type'] == 'admin_region']\n",
+    "locations_wpda = locations[locations['type'] == 'wdpa']\n",
+    "locations_basins = locations[locations['type'] == 'hydro_basin']\n",
+    "print(f'Total locations: {len(locations)}')\n",
+    "print(f'Total Sahel locations: {len(locations_sahel)}')\n",
+    "print(f'Total country locations: {len(locations_countries)}')\n",
+    "print(f'Total WDPA locations: {len(locations_wpda)}')\n",
+    "print(f'Total basin locations: {len(locations_basins)}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32c848a9",
+   "metadata": {},
+   "source": [
+    "## Wetland type per country"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a44858e3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "permopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seasopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "saline",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seas_lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "eph_lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "perinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seainuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "agri",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "reservoir",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mangrove",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mudflat",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        }
+       ],
+       "ref": "b7a4710a-4d7c-4568-8402-0584e662d1c2",
+       "rows": [
+        [
+         "0",
+         "35.08",
+         "5.03",
+         "0.17",
+         "0.0",
+         "0.1",
+         "0.01",
+         "0.02",
+         "1.07",
+         "20.62",
+         "6.03",
+         "1.02",
+         "0.0",
+         "30.83",
+         "0.033",
+         "adminregion_gmb"
+        ],
+        [
+         "2",
+         "3.99",
+         "35.47",
+         "16.94",
+         "0.22",
+         "0.21",
+         "0.81",
+         "0.15",
+         "0.09",
+         "14.44",
+         "8.71",
+         "12.08",
+         "6.84",
+         "0.0",
+         "0.038",
+         "adminregion_mrt"
+        ],
+        [
+         "3",
+         "21.84",
+         "17.21",
+         "5.22",
+         "0.35",
+         "3.3",
+         "0.25",
+         "0.42",
+         "1.39",
+         "13.76",
+         "6.19",
+         "8.61",
+         "0.81",
+         "20.59",
+         "0.061",
+         "adminregion_sen"
+        ]
+       ],
+       "shape": {
+        "columns": 15,
+        "rows": 3
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>permopen</th>\n",
+       "      <th>seasopen</th>\n",
+       "      <th>ephopen</th>\n",
+       "      <th>saline</th>\n",
+       "      <th>lake</th>\n",
+       "      <th>seas_lake</th>\n",
+       "      <th>eph_lake</th>\n",
+       "      <th>perinuveg</th>\n",
+       "      <th>seainuveg</th>\n",
+       "      <th>ephinuveg</th>\n",
+       "      <th>agri</th>\n",
+       "      <th>reservoir</th>\n",
+       "      <th>mangrove</th>\n",
+       "      <th>mudflat</th>\n",
+       "      <th>location_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>35.08</td>\n",
+       "      <td>5.03</td>\n",
+       "      <td>0.17</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.10</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>0.02</td>\n",
+       "      <td>1.07</td>\n",
+       "      <td>20.62</td>\n",
+       "      <td>6.03</td>\n",
+       "      <td>1.02</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>30.83</td>\n",
+       "      <td>0.033</td>\n",
+       "      <td>adminregion_gmb</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3.99</td>\n",
+       "      <td>35.47</td>\n",
+       "      <td>16.94</td>\n",
+       "      <td>0.22</td>\n",
+       "      <td>0.21</td>\n",
+       "      <td>0.81</td>\n",
+       "      <td>0.15</td>\n",
+       "      <td>0.09</td>\n",
+       "      <td>14.44</td>\n",
+       "      <td>8.71</td>\n",
+       "      <td>12.08</td>\n",
+       "      <td>6.84</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.038</td>\n",
+       "      <td>adminregion_mrt</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>21.84</td>\n",
+       "      <td>17.21</td>\n",
+       "      <td>5.22</td>\n",
+       "      <td>0.35</td>\n",
+       "      <td>3.30</td>\n",
+       "      <td>0.25</td>\n",
+       "      <td>0.42</td>\n",
+       "      <td>1.39</td>\n",
+       "      <td>13.76</td>\n",
+       "      <td>6.19</td>\n",
+       "      <td>8.61</td>\n",
+       "      <td>0.81</td>\n",
+       "      <td>20.59</td>\n",
+       "      <td>0.061</td>\n",
+       "      <td>adminregion_sen</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   permopen  seasopen  ephopen  saline  lake  seas_lake  eph_lake  perinuveg  \\\n",
+       "0     35.08      5.03     0.17    0.00  0.10       0.01      0.02       1.07   \n",
+       "2      3.99     35.47    16.94    0.22  0.21       0.81      0.15       0.09   \n",
+       "3     21.84     17.21     5.22    0.35  3.30       0.25      0.42       1.39   \n",
+       "\n",
+       "   seainuveg  ephinuveg   agri  reservoir  mangrove  mudflat      location_id  \n",
+       "0      20.62       6.03   1.02       0.00     30.83    0.033  adminregion_gmb  \n",
+       "2      14.44       8.71  12.08       6.84      0.00    0.038  adminregion_mrt  \n",
+       "3      13.76       6.19   8.61       0.81     20.59    0.061  adminregion_sen  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "file_path = f\"{gcs_path}/{analysis_data_folder}/Country_%25%20wetland%20type_GET%20simplified.shp\"\n",
+    "get_wetlands = gpd.read_file(file_path)\n",
+    "get_wetlands['name_en'] = get_wetlands['name_en'].replace({'The Gambia': 'Gambia'})\n",
+    "get_wetlands = get_wetlands.merge(locations_countries[['name', 'code']], left_on='name_en', right_on='name', how='left')\n",
+    "get_wetlands.drop(columns=['name_x', 'name_y', 'fid', 'osm_id', 'boundary', 'admin_leve',\n",
+    "       'admin_cent', 'admin_ce_1', 'admin_ce_2', 'label_node', 'label_no_1',\n",
+    "       'label_no_2', 'layer', 'path', 'HISTO_0', 'HISTO_11', 'HISTO_12',\n",
+    "       'HISTO_13', 'HISTO_14', 'HISTO_15', 'HISTO_16', 'HISTO_17', 'HISTO_18',\n",
+    "       'HISTO_19', 'HISTO_26', 'HISTO_27', 'HISTO_28', 'HISTO_31', 'HISTO_32',\n",
+    "       'HISTO_33', 'HISTO_34', 'HISTO_35', 'HISTO_36', 'HISTO_41', 'HISTO_42', 'tot', 'geometry'],\n",
+    "        inplace=True)\n",
+    "get_wetlands.rename(columns={'GID_0': 'code'}, inplace=True)\n",
+    "get_wetlands.dropna(subset=['code'], inplace=True)\n",
+    "get_wetlands['location_id'] = get_wetlands['code'].apply(lambda x: 'adminregion_' + x.lower())\n",
+    "get_wetlands.drop(columns=['code', 'name_en'], inplace=True)\n",
+    "get_wetlands.columns = get_wetlands.columns.str.lower().str.replace('%', '').str.strip().str.replace(' ', '_')\n",
+    "get_wetlands.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d8629c8d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "wetland_type",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "percentage",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "0685d947-9c9a-41c4-b581-dcb494700d64",
+       "rows": [
+        [
+         "260",
+         "adminregion_ben",
+         "agri",
+         "10.78"
+        ],
+        [
+         "160",
+         "adminregion_ben",
+         "eph_lake",
+         "0.07"
+        ],
+        [
+         "235",
+         "adminregion_ben",
+         "ephinuveg",
+         "38.12"
+        ]
+       ],
+       "shape": {
+        "columns": 3,
+        "rows": 3
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>wetland_type</th>\n",
+       "      <th>percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>260</th>\n",
+       "      <td>adminregion_ben</td>\n",
+       "      <td>agri</td>\n",
+       "      <td>10.78</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>160</th>\n",
+       "      <td>adminregion_ben</td>\n",
+       "      <td>eph_lake</td>\n",
+       "      <td>0.07</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>235</th>\n",
+       "      <td>adminregion_ben</td>\n",
+       "      <td>ephinuveg</td>\n",
+       "      <td>38.12</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         location_id wetland_type  percentage\n",
+       "260  adminregion_ben         agri       10.78\n",
+       "160  adminregion_ben     eph_lake        0.07\n",
+       "235  adminregion_ben    ephinuveg       38.12"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_wetlands_long = get_wetlands.melt(id_vars=['location_id'], var_name='wetland_type', value_name='percentage')\n",
+    "get_wetlands_long.sort_values(['location_id', 'wetland_type'], inplace=True)\n",
+    "get_wetlands_long.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1e01a7ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['agri', 'eph_lake', 'ephinuveg', 'ephopen', 'lake', 'mangrove',\n",
+       "       'mudflat', 'perinuveg', 'permopen', 'reservoir', 'saline',\n",
+       "       'seainuveg', 'seas_lake', 'seasopen'], dtype=object)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_wetlands_long['wetland_type'].unique()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63747244",
+   "metadata": {},
+   "source": [
+    "## Wetland types by wdpa"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f98710ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "permopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seasopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "epheopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "saltlake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seaslake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephelake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "perinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seasinveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "agricultu",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "reseirv",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mangrove",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mudflat",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        }
+       ],
+       "ref": "26fba95c-90fd-4944-91d7-adcf26dcbd62",
+       "rows": [
+        [
+         "0",
+         "2.059",
+         "7.048",
+         "1.475",
+         "0.0",
+         "0.479",
+         "0.849",
+         "3.589",
+         "0.554",
+         "28.11",
+         "47.503",
+         "0.767",
+         "0.055",
+         "7.37",
+         "0.141",
+         "wdpa_0"
+        ],
+        [
+         "1",
+         "0.024",
+         "0.438",
+         "0.04",
+         "98.734",
+         "0.0",
+         "0.0",
+         "0.0",
+         "0.069",
+         "0.499",
+         "0.196",
+         "0.0",
+         "0.0",
+         "0.0",
+         "0.0",
+         "wdpa_1"
+        ],
+        [
+         "2",
+         "0.509",
+         "13.549",
+         "0.359",
+         "78.67",
+         "0.0",
+         "0.0",
+         "0.083",
+         "0.071",
+         "4.034",
+         "2.691",
+         "0.034",
+         "0.0",
+         "0.0",
+         "0.0",
+         "wdpa_2"
+        ],
+        [
+         "3",
+         "0.333",
+         "9.63",
+         "0.713",
+         "0.0",
+         "83.336",
+         "0.393",
+         "0.0",
+         "0.033",
+         "1.062",
+         "1.627",
+         "2.873",
+         "0.0",
+         "0.0",
+         "0.0",
+         "wdpa_3"
+        ],
+        [
+         "4",
+         "0.682",
+         "0.954",
+         "0.132",
+         "84.302",
+         "0.0",
+         "0.0",
+         "0.0",
+         "0.632",
+         "5.816",
+         "7.342",
+         "0.139",
+         "0.0",
+         "0.0",
+         "0.0",
+         "wdpa_4"
+        ]
+       ],
+       "shape": {
+        "columns": 15,
+        "rows": 5
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>permopen</th>\n",
+       "      <th>seasopen</th>\n",
+       "      <th>epheopen</th>\n",
+       "      <th>saltlake</th>\n",
+       "      <th>lake</th>\n",
+       "      <th>seaslake</th>\n",
+       "      <th>ephelake</th>\n",
+       "      <th>perinuveg</th>\n",
+       "      <th>seasinveg</th>\n",
+       "      <th>ephinuveg</th>\n",
+       "      <th>agricultu</th>\n",
+       "      <th>reseirv</th>\n",
+       "      <th>mangrove</th>\n",
+       "      <th>mudflat</th>\n",
+       "      <th>location_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2.059</td>\n",
+       "      <td>7.048</td>\n",
+       "      <td>1.475</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.479</td>\n",
+       "      <td>0.849</td>\n",
+       "      <td>3.589</td>\n",
+       "      <td>0.554</td>\n",
+       "      <td>28.110</td>\n",
+       "      <td>47.503</td>\n",
+       "      <td>0.767</td>\n",
+       "      <td>0.055</td>\n",
+       "      <td>7.37</td>\n",
+       "      <td>0.141</td>\n",
+       "      <td>wdpa_0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.024</td>\n",
+       "      <td>0.438</td>\n",
+       "      <td>0.040</td>\n",
+       "      <td>98.734</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.069</td>\n",
+       "      <td>0.499</td>\n",
+       "      <td>0.196</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>wdpa_1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.509</td>\n",
+       "      <td>13.549</td>\n",
+       "      <td>0.359</td>\n",
+       "      <td>78.670</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.083</td>\n",
+       "      <td>0.071</td>\n",
+       "      <td>4.034</td>\n",
+       "      <td>2.691</td>\n",
+       "      <td>0.034</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>wdpa_2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.333</td>\n",
+       "      <td>9.630</td>\n",
+       "      <td>0.713</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>83.336</td>\n",
+       "      <td>0.393</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.033</td>\n",
+       "      <td>1.062</td>\n",
+       "      <td>1.627</td>\n",
+       "      <td>2.873</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>wdpa_3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.682</td>\n",
+       "      <td>0.954</td>\n",
+       "      <td>0.132</td>\n",
+       "      <td>84.302</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.632</td>\n",
+       "      <td>5.816</td>\n",
+       "      <td>7.342</td>\n",
+       "      <td>0.139</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>wdpa_4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   permopen  seasopen  epheopen  saltlake    lake  seaslake  ephelake  \\\n",
+       "0     2.059     7.048     1.475     0.000   0.479     0.849     3.589   \n",
+       "1     0.024     0.438     0.040    98.734   0.000     0.000     0.000   \n",
+       "2     0.509    13.549     0.359    78.670   0.000     0.000     0.083   \n",
+       "3     0.333     9.630     0.713     0.000  83.336     0.393     0.000   \n",
+       "4     0.682     0.954     0.132    84.302   0.000     0.000     0.000   \n",
+       "\n",
+       "   perinuveg  seasinveg  ephinuveg  agricultu  reseirv  mangrove  mudflat  \\\n",
+       "0      0.554     28.110     47.503      0.767    0.055      7.37    0.141   \n",
+       "1      0.069      0.499      0.196      0.000    0.000      0.00    0.000   \n",
+       "2      0.071      4.034      2.691      0.034    0.000      0.00    0.000   \n",
+       "3      0.033      1.062      1.627      2.873    0.000      0.00    0.000   \n",
+       "4      0.632      5.816      7.342      0.139    0.000      0.00    0.000   \n",
+       "\n",
+       "  location_id  \n",
+       "0      wdpa_0  \n",
+       "1      wdpa_1  \n",
+       "2      wdpa_2  \n",
+       "3      wdpa_3  \n",
+       "4      wdpa_4  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "file_path = f\"{gcs_path}/{analysis_data_folder}/WDPA_%25_wetland%20type_GET.shp\"\n",
+    "get_wdpa = gpd.read_file(file_path)\n",
+    "get_wdpa.drop(columns=['fid', 'v_idris', 'ramsarid', 'officialna', 'iso3', 'country_en',\n",
+    "       'area_off', 'OBJECTID', 'WDPAID', 'WDPA_PID', 'PA_DEF', 'NAME',\n",
+    "       'ORIG_NAME', 'DESIG', 'DESIG_ENG', 'DESIG_TYPE', 'IUCN_CAT', 'INT_CRIT',\n",
+    "       'MARINE', 'REP_M_AREA', 'GIS_M_AREA', 'REP_AREA', 'GIS_AREA', 'NO_TAKE',\n",
+    "       'NO_TK_AREA', 'STATUS', 'STATUS_YR', 'GOV_TYPE', 'OWN_TYPE',\n",
+    "       'MANG_AUTH', 'MANG_PLAN', 'VERIF', 'METADATAID', 'SUB_LOC',\n",
+    "       'PARENT_ISO', 'SUPP_INFO', 'CONS_OBJ', 'layer', 'path', 'PARENT_I_1',\n",
+    "       'Area_new', 'HISTO_0', 'HISTO_11', 'HISTO_12', 'HISTO_13', 'HISTO_14',\n",
+    "       'HISTO_15', 'HISTO_16', 'HISTO_17', 'HISTO_18', 'HISTO_19', 'HISTO_26',\n",
+    "       'HISTO_27', 'HISTO_28', 'HISTO_31', 'HISTO_32', 'HISTO_33', 'HISTO_34',\n",
+    "       'HISTO_35', 'HISTO_36', 'HISTO_41', 'HISTO_42', 'HISTO_TOT', 'geometry'],\n",
+    "        inplace=True)\n",
+    "get_wdpa['location_id'] = get_wdpa.index.to_series().apply(lambda x: f\"wdpa_{x}\")\n",
+    "get_wdpa.columns = get_wdpa.columns.str.lower().str.replace('%', '').str.strip().str.replace(' ', '_')\n",
+    "get_wdpa.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "75923f90",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "wetland_type",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "percentage",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "fd878c38-b554-4e5c-8c59-e10261a94a3e",
+       "rows": [
+        [
+         "20240",
+         "wdpa_0",
+         "agricultu",
+         "0.767"
+        ],
+        [
+         "12144",
+         "wdpa_0",
+         "ephelake",
+         "3.589"
+        ],
+        [
+         "4048",
+         "wdpa_0",
+         "epheopen",
+         "1.475"
+        ]
+       ],
+       "shape": {
+        "columns": 3,
+        "rows": 3
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>wetland_type</th>\n",
+       "      <th>percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>20240</th>\n",
+       "      <td>wdpa_0</td>\n",
+       "      <td>agricultu</td>\n",
+       "      <td>0.767</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12144</th>\n",
+       "      <td>wdpa_0</td>\n",
+       "      <td>ephelake</td>\n",
+       "      <td>3.589</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4048</th>\n",
+       "      <td>wdpa_0</td>\n",
+       "      <td>epheopen</td>\n",
+       "      <td>1.475</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      location_id wetland_type  percentage\n",
+       "20240      wdpa_0    agricultu       0.767\n",
+       "12144      wdpa_0     ephelake       3.589\n",
+       "4048       wdpa_0     epheopen       1.475"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_wdpa_long = get_wdpa.melt(id_vars=['location_id'], var_name='wetland_type', value_name='percentage')\n",
+    "get_wdpa_long.sort_values(['location_id', 'wetland_type'], inplace=True)\n",
+    "get_wdpa_long.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "29c33ec7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "types_dict = {\n",
+    " 'agricultu': 'agri',\n",
+    " 'ephelake': 'eph_lake',\n",
+    " 'epheopen': 'ephopen',\n",
+    " 'ephinuveg': 'ephinuveg',\n",
+    " 'lake': 'lake',\n",
+    " 'mangrove': 'mangrove',\n",
+    " 'mudflat': 'mudflat',\n",
+    " 'perinuveg': 'perinuveg',\n",
+    " 'permopen': 'permopen',\n",
+    " 'reseirv': 'reservoir',\n",
+    " 'saltlake': 'saline',\n",
+    " 'seasinveg': 'seainuveg',\n",
+    " 'seaslake': 'seas_lake',\n",
+    " 'seasopen': 'seasopen'\n",
+    " }\n",
+    "get_wdpa_long['wetland_type'] = get_wdpa_long['wetland_type'].map(types_dict)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be1798d5",
+   "metadata": {},
+   "source": [
+    "## Wetland types by hydrobasin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "10f32d4c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "wetland_type",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "percentage",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "a6a0f747-2cd2-437d-8a99-938660d5311d",
+       "rows": [
+        [
+         "174",
+         "hydrobasin_congo_basin",
+         "agri",
+         "0.318"
+        ],
+        [
+         "106",
+         "hydrobasin_congo_basin",
+         "eph_lake",
+         "0.149"
+        ],
+        [
+         "157",
+         "hydrobasin_congo_basin",
+         "ephinuveg",
+         "59.573"
+        ]
+       ],
+       "shape": {
+        "columns": 3,
+        "rows": 3
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>wetland_type</th>\n",
+       "      <th>percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>174</th>\n",
+       "      <td>hydrobasin_congo_basin</td>\n",
+       "      <td>agri</td>\n",
+       "      <td>0.318</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>106</th>\n",
+       "      <td>hydrobasin_congo_basin</td>\n",
+       "      <td>eph_lake</td>\n",
+       "      <td>0.149</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>157</th>\n",
+       "      <td>hydrobasin_congo_basin</td>\n",
+       "      <td>ephinuveg</td>\n",
+       "      <td>59.573</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                location_id wetland_type  percentage\n",
+       "174  hydrobasin_congo_basin         agri       0.318\n",
+       "106  hydrobasin_congo_basin     eph_lake       0.149\n",
+       "157  hydrobasin_congo_basin    ephinuveg      59.573"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "file_path = f\"{gcs_path}/{analysis_data_folder}/Hydrobasins_%25%20wetland%20type_GET.shp\"\n",
+    "get_hydrobasins = gpd.read_file(file_path)\n",
+    "get_hydrobasins.drop(columns=['NEXT_DOWN', 'NEXT_SINK', 'MAIN_BAS', 'DIST_SINK',\n",
+    "       'DIST_MAIN', 'SUB_AREA', 'UP_AREA', 'PFAF_ID', 'ENDO', 'COAST', 'ORDER',\n",
+    "       'SORT', 'HISTO_0', 'HISTO_TOT', 'HISTO_11', 'HISTO_12', 'HISTO_13',\n",
+    "       'HISTO_14', 'HISTO_15', 'HISTO_16', 'HISTO_17', 'HISTO_18', 'HISTO_19',\n",
+    "       'HISTO_26', 'HISTO_27', 'HISTO_28', 'HISTO_31', 'HISTO_32', 'HISTO_33',\n",
+    "       'HISTO_34', 'HISTO_35', 'HISTO_36', 'HISTO_41', 'HISTO_42','geometry'],\n",
+    "        inplace=True)\n",
+    "get_hydrobasins['HYBAS_ID'] = get_hydrobasins['HYBAS_ID'].astype(str)\n",
+    "\n",
+    "get_hydrobasins = pd.merge(get_hydrobasins, locations_basins[['id', 'code']], left_on='HYBAS_ID', right_on='code', how='left')\n",
+    "get_hydrobasins.drop(columns=['code', 'HYBAS_ID'], inplace=True)\n",
+    "get_hydrobasins.dropna(subset=['id'], inplace=True)\n",
+    "get_hydrobasins.columns = get_hydrobasins.columns.str.lower().str.replace('%', '').str.strip().str.replace(' ', '_')\n",
+    "get_hydrobasins.rename(columns={'id': 'location_id'}, inplace=True)\n",
+    "get_hydrobasins_long = get_hydrobasins.melt(id_vars=['location_id'], var_name='wetland_type', value_name='percentage')\n",
+    "\n",
+    "\n",
+    "types_dict = {\n",
+    "    'agricult':'agri',\n",
+    "    'ephelake':'eph_lake',\n",
+    "    'ephinveg':'ephinuveg',\n",
+    "    'epheopen':'ephopen',\n",
+    "    'lake':'lake',\n",
+    "    'mangrove':'mangrove',\n",
+    "    'perminveg':'perinuveg',\n",
+    "    'permopen':'permopen',\n",
+    "    'reseivoir':'reservoir',\n",
+    "    'saltlake':'saline',\n",
+    "    'seasinveg':'seainuveg',\n",
+    "    'seaslake':'seas_lake',\n",
+    "    'seasopen':'seasopen',\n",
+    "    'mudflat':'mudflat'\n",
+    "}\n",
+    "get_hydrobasins_long['wetland_type'] = get_hydrobasins_long['wetland_type'].map(types_dict)\n",
+    "get_hydrobasins_long.sort_values(['location_id', 'wetland_type'], inplace=True)\n",
+    "get_hydrobasins_long.head(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e66cc24d",
+   "metadata": {},
+   "source": [
+    "## Wetland types Sahel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "85fa3f73",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "wetland_type",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "percentage",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "722c7fd1-0c88-4aa5-a505-1f8e1f2d84fc",
+       "rows": [
+        [
+         "10",
+         "global_sahel",
+         "agri",
+         "14.16"
+        ],
+        [
+         "6",
+         "global_sahel",
+         "eph_lake",
+         "0.12"
+        ],
+        [
+         "9",
+         "global_sahel",
+         "ephinuveg",
+         "27.0"
+        ]
+       ],
+       "shape": {
+        "columns": 3,
+        "rows": 3
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>wetland_type</th>\n",
+       "      <th>percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>global_sahel</td>\n",
+       "      <td>agri</td>\n",
+       "      <td>14.16</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>global_sahel</td>\n",
+       "      <td>eph_lake</td>\n",
+       "      <td>0.12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>global_sahel</td>\n",
+       "      <td>ephinuveg</td>\n",
+       "      <td>27.00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     location_id wetland_type  percentage\n",
+       "10  global_sahel         agri       14.16\n",
+       "6   global_sahel     eph_lake        0.12\n",
+       "9   global_sahel    ephinuveg       27.00"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "file_path = f\"{gcs_path}/{analysis_data_folder}/Sahel_%25%20wetland%20type_GET%20simplified.shp\"\n",
+    "get_sahel = gpd.read_file(file_path)\n",
+    "get_sahel.drop(columns=['fid', 'Id', 'HISTO_0', 'HISTO_11', 'HISTO_12', 'HISTO_13', 'HISTO_14',\n",
+    "       'HISTO_15', 'HISTO_16', 'HISTO_17', 'HISTO_18', 'HISTO_19', 'HISTO_26',\n",
+    "       'HISTO_27', 'HISTO_28', 'HISTO_31', 'HISTO_32', 'HISTO_33', 'HISTO_34',\n",
+    "       'HISTO_35', 'HISTO_36', 'HISTO_41', 'HISTO_42', 'tot', 'geometry'], inplace=True)\n",
+    "get_sahel['location_id'] = 'global_sahel'\n",
+    "get_sahel.columns = get_sahel.columns.str.lower().str.replace('%', '').str.strip().str.replace(' ', '_')\n",
+    "get_sahel_long = get_sahel.melt(id_vars=['location_id'], var_name='wetland_type', value_name='percentage')\n",
+    "get_sahel_long.sort_values(['location_id', 'wetland_type'], inplace=True)\n",
+    "get_sahel_long['wetland_type'] = get_sahel_long['wetland_type'].str.replace('agri_sum', 'agri')\n",
+    "get_sahel_long.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "6ba6f626",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "types_dict = {\n",
+    "    'agri':'agri',\n",
+    "    'eph_lake':'eph_lake',\n",
+    "    'ephinuveg':'ephinuveg',\n",
+    "    'ephopen':'ephopen',\n",
+    "    'lake':'lake',\n",
+    "    'mangrove':'mangrove',\n",
+    "    'perinuveg':'perinuveg',\n",
+    "    'perm_open':'permopen',\n",
+    "    'reserv':'reservoir',\n",
+    "    'saline':'saline',\n",
+    "    'seasinveg':'seainuveg',\n",
+    "    'seas_lake':'seas_lake',\n",
+    "    'seasopen':'seasopen'\n",
+    "}\n",
+    "get_sahel_long['wetland_type'] = get_sahel_long['wetland_type'].map(types_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "20a2666b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "14\n",
+      "14\n",
+      "14\n",
+      "13\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(len(get_wetlands_long['wetland_type'].unique()))\n",
+    "print(len(get_wdpa_long['wetland_type'].unique()))\n",
+    "print(len(get_hydrobasins_long['wetland_type'].unique()))\n",
+    "print(len(get_sahel_long['wetland_type'].unique()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f179e64",
+   "metadata": {},
+   "source": [
+    "## Combine all data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "547fbe32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_combined = pd.concat([get_wetlands_long, get_wdpa_long, get_hydrobasins_long, get_sahel_long], ignore_index=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b33eaeca",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "14\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array(['agri', 'eph_lake', 'ephinuveg', 'ephopen', 'lake', 'mangrove',\n",
+       "       'mudflat', 'perinuveg', 'permopen', 'reservoir', 'saline',\n",
+       "       'seainuveg', 'seas_lake', 'seasopen'], dtype=object)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(len(get_combined['wetland_type'].unique()))\n",
+    "get_combined['wetland_type'].unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "95f48f84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Replace Na with 0\n",
+    "get_combined['percentage'] = get_combined['percentage'].replace(np.nan, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "0a22507e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "color_dict = {'agri':\"#ff9067\",\n",
+    "              'eph_lake': \"#9499ff\",\n",
+    "              'ephinuveg': \"#9ec59e\",\n",
+    "              'ephopen': \"#f6ffff\",\n",
+    "              'lake': \"#000dff\",\n",
+    "              'mangrove': \"#663399\",\n",
+    "              'mudflat': \"#a0522d\",\n",
+    "              'perinuveg': \"#006400\",\n",
+    "              'permopen': \"#7acaff\",\n",
+    "              'reservoir': \"#56b98b\",\n",
+    "              'saline': \"#cfe875\",\n",
+    "              'seainuveg': \"#8bc500\",\n",
+    "              'seas_lake': \"#4747ff\",\n",
+    "              'seasopen': \"#e2ffff\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "142b4b61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indicator_data_list = []\n",
+    "\n",
+    "for location in get_combined['location_id'].unique():\n",
+    "    df_location = get_combined[get_combined['location_id'] == location]\n",
+    "    df_location.reset_index(drop=True, inplace=True)\n",
+    "    data_list = []\n",
+    "    for i in range(len(df_location)):\n",
+    "        data_list.append({\n",
+    "            \"id\":\"wetland_type_\" + location + \"_\" + str(i),\n",
+    "            \"label\": df_location.loc[i, 'wetland_type'],\n",
+    "            \"value\": df_location.loc[i, 'percentage'],\n",
+    "            \"type\":\"\",\n",
+    "            \"group\": \"\",\n",
+    "            \"color\": color_dict.get(df_location.loc[i, 'wetland_type'], \"#000000\"),\n",
+    "            \"format\": \"number\",\n",
+    "            \"unit\": \"%\"\n",
+    "        })\n",
+    "    data_json = json.dumps(data_list, indent=2)\n",
+    "    temp_dict = {\"id\": \"wetland-types-\" + location,\n",
+    "                 \"location\": location,\n",
+    "                 \"indicator\": \"wetland-types-get\",\n",
+    "                 \"data\": json.loads(data_json),\n",
+    "                 \"locale\": {\"en\": {\"labels\":{\n",
+    "                     'agri':'Agriculture',\n",
+    "                     'eph_lake':'Ephemeral Lake',\n",
+    "                     'ephinuveg':'Ephemeral Inundated Vegetation',\n",
+    "                     'ephopen':'Ephemeral Open Water',\n",
+    "                     'lake':'Lake',\n",
+    "                     'mangrove':'Mangrove',\n",
+    "                     'mudflat':'Mudflat',\n",
+    "                     'perinuveg':'Permanently Inundated Vegetation',\n",
+    "                     'permopen':'Permanent Open Water',\n",
+    "                     'reservoir':'Reservoir',\n",
+    "                     'saline':'Saline',\n",
+    "                     'seainuveg':'Seasonally Inundated Vegetation',\n",
+    "                     'seas_lake':'Seasonal Lake',\n",
+    "                     'seasopen':'Seasonal Open Water'\n",
+    "                    }\n",
+    "                    }},\n",
+    "                }\n",
+    "    indicator_data_list.append(temp_dict)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "ae523e53",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"id\": \"wetland-types-adminregion_ben\",\n",
+      "  \"location\": \"adminregion_ben\",\n",
+      "  \"indicator\": \"wetland-types-get\",\n",
+      "  \"data\": [\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_0\",\n",
+      "      \"label\": \"agri\",\n",
+      "      \"value\": 10.78,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#ff9067\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_1\",\n",
+      "      \"label\": \"eph_lake\",\n",
+      "      \"value\": 0.07,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#9499ff\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_2\",\n",
+      "      \"label\": \"ephinuveg\",\n",
+      "      \"value\": 38.12,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#9ec59e\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_3\",\n",
+      "      \"label\": \"ephopen\",\n",
+      "      \"value\": 3.4,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#f6ffff\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_4\",\n",
+      "      \"label\": \"lake\",\n",
+      "      \"value\": 0.0,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#000dff\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_5\",\n",
+      "      \"label\": \"mangrove\",\n",
+      "      \"value\": 1.89,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#663399\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_6\",\n",
+      "      \"label\": \"mudflat\",\n",
+      "      \"value\": 0.0,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#a0522d\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_7\",\n",
+      "      \"label\": \"perinuveg\",\n",
+      "      \"value\": 0.15,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#006400\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_8\",\n",
+      "      \"label\": \"permopen\",\n",
+      "      \"value\": 2.25,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#7acaff\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_9\",\n",
+      "      \"label\": \"reservoir\",\n",
+      "      \"value\": 0.32,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#56b98b\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_10\",\n",
+      "      \"label\": \"saline\",\n",
+      "      \"value\": 1.68,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#cfe875\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_11\",\n",
+      "      \"label\": \"seainuveg\",\n",
+      "      \"value\": 31.78,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#8bc500\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_12\",\n",
+      "      \"label\": \"seas_lake\",\n",
+      "      \"value\": 1.37,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#4747ff\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_13\",\n",
+      "      \"label\": \"seasopen\",\n",
+      "      \"value\": 8.2,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#e2ffff\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    }\n",
+      "  ],\n",
+      "  \"locale\": {\n",
+      "    \"en\": {\n",
+      "      \"labels\": {\n",
+      "        \"agri\": \"Agriculture\",\n",
+      "        \"eph_lake\": \"Ephemeral Lake\",\n",
+      "        \"ephinuveg\": \"Ephemeral Inundated Vegetation\",\n",
+      "        \"ephopen\": \"Ephemeral Open Water\",\n",
+      "        \"lake\": \"Lake\",\n",
+      "        \"mangrove\": \"Mangrove\",\n",
+      "        \"mudflat\": \"Mudflat\",\n",
+      "        \"perinuveg\": \"Permanently Inundated Vegetation\",\n",
+      "        \"permopen\": \"Permanent Open Water\",\n",
+      "        \"reservoir\": \"Reservoir\",\n",
+      "        \"saline\": \"Saline\",\n",
+      "        \"seainuveg\": \"Seasonally Inundated Vegetation\",\n",
+      "        \"seas_lake\": \"Seasonal Lake\",\n",
+      "        \"seasopen\": \"Seasonal Open Water\"\n",
+      "      }\n",
+      "    }\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(json.dumps(indicator_data_list[0], indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8eba2821",
+   "metadata": {},
+   "source": [
+    "### Save to json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "48a1254d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seeding_json = json.load(open('../../app-initial-data/indicator-data.json'))\n",
+    "#remove all entries with id that starts with \"wetland-types-\" and \"wetland_types_\"\n",
+    "seeding_json = [entry for entry in seeding_json if not entry['id'].startswith('wetland-types-') and not entry['id'].startswith('wetland_types_')]\n",
+    "\n",
+    "# Append the new data, if id exists update it\n",
+    "existing_ids = {entry['id'] for entry in seeding_json}\n",
+    "for new_entry in indicator_data_list:\n",
+    "    if new_entry['id'] in existing_ids:\n",
+    "        seeding_json = [entry if entry['id'] != new_entry['id'] else new_entry for entry in seeding_json]\n",
+    "    else:\n",
+    "        seeding_json.append(new_entry)  \n",
+    "with open('../../app-initial-data/indicator-data.json', 'w') as f:\n",
+    "    json.dump(seeding_json, f, indent=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20861fbd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pyFIP",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/data-processing/notebooks/07a_UPDATED_wetlands_inventory_data.ipynb
+++ b/data-processing/notebooks/07a_UPDATED_wetlands_inventory_data.ipynb
@@ -1,0 +1,2966 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b3aae68c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import geopandas as gpd\n",
+    "import json\n",
+    "import os\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c516c608",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gcs_path = \"https://storage.googleapis.com/wetlands-gap-map/original_data\"\n",
+    "analysis_data_folder = 'updated_typology_csv'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2b06ac31",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total locations: 2068\n",
+      "Total Sahel locations: 1\n",
+      "Total country locations: 26\n",
+      "Total WDPA locations: 2024\n",
+      "Total basin locations: 17\n"
+     ]
+    }
+   ],
+   "source": [
+    "locations = gpd.read_file(f'{gcs_path}/locations_simplified.geojson')\n",
+    "locations_sahel = locations[locations['type'] == 'global']\n",
+    "locations_countries = locations[locations['type'] == 'admin_region']\n",
+    "locations_wpda = locations[locations['type'] == 'wdpa']\n",
+    "locations_basins = locations[locations['type'] == 'hydro_basin']\n",
+    "print(f'Total locations: {len(locations)}')\n",
+    "print(f'Total Sahel locations: {len(locations_sahel)}')\n",
+    "print(f'Total country locations: {len(locations_countries)}')\n",
+    "print(f'Total WDPA locations: {len(locations_wpda)}')\n",
+    "print(f'Total basin locations: {len(locations_basins)}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "42a90c06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Column names dictionary\n",
+    "cols_dict = {\n",
+    "    '11': 'permopen',\n",
+    "    '12': 'seasopen',\n",
+    "    '13': 'ephopen',\n",
+    "    '14': 'saline',\n",
+    "    '17': 'lake',\n",
+    "    '18': 'seas_lake',\n",
+    "    '19': 'eph_lake',\n",
+    "    '26': 'perinuveg',\n",
+    "    '27': 'seainuveg',\n",
+    "    '28': 'ephinuveg',\n",
+    "    '32': 'agri',\n",
+    "    '34': 'reservoir',\n",
+    "    '41': 'mangrove',\n",
+    "    '42': 'mudflat',\n",
+    "    '128': 'shallow',\n",
+    "    '43': 'other'\n",
+    "}\n",
+    "\n",
+    "wetland_types = list(cols_dict.values())\n",
+    "wetland_types.remove('other')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32c848a9",
+   "metadata": {},
+   "source": [
+    "## Wetland type per country"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "77cbabb9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "Country",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "permopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seasopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "saline",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seas_lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "eph_lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "perinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seainuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "agri",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "reservoir",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mangrove",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mudflat",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "shallow",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "total",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "code",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        }
+       ],
+       "ref": "d61ef89b-13a8-46c8-b52a-20ede0265dd7",
+       "rows": [
+        [
+         "0",
+         "Senegal",
+         "204910.29",
+         "143463.69",
+         "42353.64",
+         "332.55",
+         "26354.52",
+         "4522.77",
+         "3328.92",
+         "11460.33",
+         "108794.97",
+         "50312.79",
+         "69208.83",
+         "5989.860000000001",
+         "172101.24",
+         "21246.93",
+         "206759.79",
+         "1071141.12",
+         "SEN",
+         "adminregion_sen"
+        ],
+        [
+         "1",
+         "Gambia",
+         "48123.18",
+         "12514.23",
+         "415.71",
+         "0.0",
+         "219.69",
+         "21.33",
+         "47.52",
+         "2547.72",
+         "50198.67",
+         "15355.44",
+         "2607.75",
+         "0.27",
+         "78100.29",
+         "7791.66",
+         "124499.16",
+         "342442.62",
+         "GMB",
+         "adminregion_gmb"
+        ],
+        [
+         "2",
+         "Kenya",
+         "41599.26",
+         "262270.26",
+         "78160.32",
+         "754345.7100000001",
+         "394836.3",
+         "4796.46",
+         "9500.94",
+         "6014.52",
+         "121057.47",
+         "164236.86",
+         "103789.62",
+         "15802.47",
+         "54379.71",
+         "30144.96",
+         "127666.26",
+         "2168601.12",
+         "KEN",
+         "adminregion_ken"
+        ],
+        [
+         "3",
+         "South Sudan",
+         "48208.23",
+         "492621.12",
+         "119927.07",
+         "134.19",
+         "71593.74",
+         "11616.66",
+         "6103.17",
+         "178421.67",
+         "7008218.37",
+         "5646269.7",
+         "60432.03",
+         "17975.34",
+         "0.0",
+         "0.0",
+         "0.0",
+         "13661521.29",
+         "SSD",
+         "adminregion_ssd"
+        ],
+        [
+         "4",
+         "Mauritania",
+         "10907.82",
+         "103820.22",
+         "46998.72",
+         "1100.7",
+         "573.12",
+         "3114.2700000000004",
+         "393.12",
+         "224.73",
+         "42477.3",
+         "23834.07",
+         "32530.86",
+         "18068.94",
+         "310.41",
+         "4885.74",
+         "19967.04",
+         "309207.05999999994",
+         "MRT",
+         "adminregion_mrt"
+        ]
+       ],
+       "shape": {
+        "columns": 19,
+        "rows": 5
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Country</th>\n",
+       "      <th>permopen</th>\n",
+       "      <th>seasopen</th>\n",
+       "      <th>ephopen</th>\n",
+       "      <th>saline</th>\n",
+       "      <th>lake</th>\n",
+       "      <th>seas_lake</th>\n",
+       "      <th>eph_lake</th>\n",
+       "      <th>perinuveg</th>\n",
+       "      <th>seainuveg</th>\n",
+       "      <th>ephinuveg</th>\n",
+       "      <th>agri</th>\n",
+       "      <th>reservoir</th>\n",
+       "      <th>mangrove</th>\n",
+       "      <th>mudflat</th>\n",
+       "      <th>shallow</th>\n",
+       "      <th>total</th>\n",
+       "      <th>code</th>\n",
+       "      <th>location_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Senegal</td>\n",
+       "      <td>204910.29</td>\n",
+       "      <td>143463.69</td>\n",
+       "      <td>42353.64</td>\n",
+       "      <td>332.55</td>\n",
+       "      <td>26354.52</td>\n",
+       "      <td>4522.77</td>\n",
+       "      <td>3328.92</td>\n",
+       "      <td>11460.33</td>\n",
+       "      <td>108794.97</td>\n",
+       "      <td>50312.79</td>\n",
+       "      <td>69208.83</td>\n",
+       "      <td>5989.86</td>\n",
+       "      <td>172101.24</td>\n",
+       "      <td>21246.93</td>\n",
+       "      <td>206759.79</td>\n",
+       "      <td>1071141.12</td>\n",
+       "      <td>SEN</td>\n",
+       "      <td>adminregion_sen</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Gambia</td>\n",
+       "      <td>48123.18</td>\n",
+       "      <td>12514.23</td>\n",
+       "      <td>415.71</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>219.69</td>\n",
+       "      <td>21.33</td>\n",
+       "      <td>47.52</td>\n",
+       "      <td>2547.72</td>\n",
+       "      <td>50198.67</td>\n",
+       "      <td>15355.44</td>\n",
+       "      <td>2607.75</td>\n",
+       "      <td>0.27</td>\n",
+       "      <td>78100.29</td>\n",
+       "      <td>7791.66</td>\n",
+       "      <td>124499.16</td>\n",
+       "      <td>342442.62</td>\n",
+       "      <td>GMB</td>\n",
+       "      <td>adminregion_gmb</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Kenya</td>\n",
+       "      <td>41599.26</td>\n",
+       "      <td>262270.26</td>\n",
+       "      <td>78160.32</td>\n",
+       "      <td>754345.71</td>\n",
+       "      <td>394836.30</td>\n",
+       "      <td>4796.46</td>\n",
+       "      <td>9500.94</td>\n",
+       "      <td>6014.52</td>\n",
+       "      <td>121057.47</td>\n",
+       "      <td>164236.86</td>\n",
+       "      <td>103789.62</td>\n",
+       "      <td>15802.47</td>\n",
+       "      <td>54379.71</td>\n",
+       "      <td>30144.96</td>\n",
+       "      <td>127666.26</td>\n",
+       "      <td>2168601.12</td>\n",
+       "      <td>KEN</td>\n",
+       "      <td>adminregion_ken</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>South Sudan</td>\n",
+       "      <td>48208.23</td>\n",
+       "      <td>492621.12</td>\n",
+       "      <td>119927.07</td>\n",
+       "      <td>134.19</td>\n",
+       "      <td>71593.74</td>\n",
+       "      <td>11616.66</td>\n",
+       "      <td>6103.17</td>\n",
+       "      <td>178421.67</td>\n",
+       "      <td>7008218.37</td>\n",
+       "      <td>5646269.70</td>\n",
+       "      <td>60432.03</td>\n",
+       "      <td>17975.34</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>13661521.29</td>\n",
+       "      <td>SSD</td>\n",
+       "      <td>adminregion_ssd</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Mauritania</td>\n",
+       "      <td>10907.82</td>\n",
+       "      <td>103820.22</td>\n",
+       "      <td>46998.72</td>\n",
+       "      <td>1100.70</td>\n",
+       "      <td>573.12</td>\n",
+       "      <td>3114.27</td>\n",
+       "      <td>393.12</td>\n",
+       "      <td>224.73</td>\n",
+       "      <td>42477.30</td>\n",
+       "      <td>23834.07</td>\n",
+       "      <td>32530.86</td>\n",
+       "      <td>18068.94</td>\n",
+       "      <td>310.41</td>\n",
+       "      <td>4885.74</td>\n",
+       "      <td>19967.04</td>\n",
+       "      <td>309207.06</td>\n",
+       "      <td>MRT</td>\n",
+       "      <td>adminregion_mrt</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       Country   permopen   seasopen    ephopen     saline       lake  \\\n",
+       "0      Senegal  204910.29  143463.69   42353.64     332.55   26354.52   \n",
+       "1       Gambia   48123.18   12514.23     415.71       0.00     219.69   \n",
+       "2        Kenya   41599.26  262270.26   78160.32  754345.71  394836.30   \n",
+       "3  South Sudan   48208.23  492621.12  119927.07     134.19   71593.74   \n",
+       "4   Mauritania   10907.82  103820.22   46998.72    1100.70     573.12   \n",
+       "\n",
+       "   seas_lake  eph_lake  perinuveg   seainuveg   ephinuveg       agri  \\\n",
+       "0    4522.77   3328.92   11460.33   108794.97    50312.79   69208.83   \n",
+       "1      21.33     47.52    2547.72    50198.67    15355.44    2607.75   \n",
+       "2    4796.46   9500.94    6014.52   121057.47   164236.86  103789.62   \n",
+       "3   11616.66   6103.17  178421.67  7008218.37  5646269.70   60432.03   \n",
+       "4    3114.27    393.12     224.73    42477.30    23834.07   32530.86   \n",
+       "\n",
+       "   reservoir   mangrove   mudflat    shallow        total code  \\\n",
+       "0    5989.86  172101.24  21246.93  206759.79   1071141.12  SEN   \n",
+       "1       0.27   78100.29   7791.66  124499.16    342442.62  GMB   \n",
+       "2   15802.47   54379.71  30144.96  127666.26   2168601.12  KEN   \n",
+       "3   17975.34       0.00      0.00       0.00  13661521.29  SSD   \n",
+       "4   18068.94     310.41   4885.74   19967.04    309207.06  MRT   \n",
+       "\n",
+       "       location_id  \n",
+       "0  adminregion_sen  \n",
+       "1  adminregion_gmb  \n",
+       "2  adminregion_ken  \n",
+       "3  adminregion_ssd  \n",
+       "4  adminregion_mrt  "
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "file_path = f'{gcs_path}/{analysis_data_folder}/admin_region_areas.csv'\n",
+    "get_wetlands = pd.read_csv(file_path)\n",
+    "#replace column names with the dictionary\n",
+    "get_wetlands = get_wetlands.rename(columns=cols_dict)\n",
+    "\n",
+    "#group categories\n",
+    "get_wetlands['seas_lake'] = get_wetlands['seas_lake'] + get_wetlands['15']\n",
+    "get_wetlands['saline'] = get_wetlands['saline'] + get_wetlands['16']\n",
+    "get_wetlands['agri'] = get_wetlands['agri'] + get_wetlands['31'] + get_wetlands['33']\n",
+    "get_wetlands['reservoir'] = get_wetlands['reservoir'] + get_wetlands['35'] + get_wetlands['36']\n",
+    "\n",
+    "get_wetlands = get_wetlands.drop(columns=['15', '16', '31', '33', '35', '36', 'other'])\n",
+    "\n",
+    "get_wetlands['total'] = get_wetlands[wetland_types].sum(axis=1)\n",
+    "\n",
+    "#clean names\n",
+    "get_wetlands['Country'] = get_wetlands['Country'].replace({'The Gambia': 'Gambia'})\n",
+    "#Right join to preserve countries only in the locations_countries dataframe\n",
+    "get_wetlands = get_wetlands.merge(locations_countries[['name', 'code']], left_on='Country', right_on='name', how='right')\n",
+    "get_wetlands = get_wetlands.drop(columns=['name'])\n",
+    "get_wetlands['location_id'] = get_wetlands['code'].apply(lambda x: 'adminregion_' + x.lower())\n",
+    "\n",
+    "get_wetlands.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "7407892b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "permopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seasopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "saline",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seas_lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "eph_lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "perinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seainuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "agri",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "reservoir",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mangrove",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mudflat",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "shallow",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "cb266cc7-34a9-4e0e-a777-947ff5fab6f7",
+       "rows": [
+        [
+         "0",
+         "adminregion_sen",
+         "19.13",
+         "13.39",
+         "3.95",
+         "0.03",
+         "2.46",
+         "0.42",
+         "0.31",
+         "1.07",
+         "10.16",
+         "4.7",
+         "6.46",
+         "0.56",
+         "16.07",
+         "1.98",
+         "19.3"
+        ],
+        [
+         "1",
+         "adminregion_gmb",
+         "14.05",
+         "3.65",
+         "0.12",
+         "0.0",
+         "0.06",
+         "0.01",
+         "0.01",
+         "0.74",
+         "14.66",
+         "4.48",
+         "0.76",
+         "0.0",
+         "22.81",
+         "2.28",
+         "36.36"
+        ],
+        [
+         "2",
+         "adminregion_ken",
+         "1.92",
+         "12.09",
+         "3.6",
+         "34.78",
+         "18.21",
+         "0.22",
+         "0.44",
+         "0.28",
+         "5.58",
+         "7.57",
+         "4.79",
+         "0.73",
+         "2.51",
+         "1.39",
+         "5.89"
+        ],
+        [
+         "3",
+         "adminregion_ssd",
+         "0.35",
+         "3.61",
+         "0.88",
+         "0.0",
+         "0.52",
+         "0.09",
+         "0.04",
+         "1.31",
+         "51.3",
+         "41.33",
+         "0.44",
+         "0.13",
+         "0.0",
+         "0.0",
+         "0.0"
+        ],
+        [
+         "4",
+         "adminregion_mrt",
+         "3.53",
+         "33.58",
+         "15.2",
+         "0.36",
+         "0.19",
+         "1.01",
+         "0.13",
+         "0.07",
+         "13.74",
+         "7.71",
+         "10.52",
+         "5.84",
+         "0.1",
+         "1.58",
+         "6.46"
+        ]
+       ],
+       "shape": {
+        "columns": 16,
+        "rows": 5
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>permopen</th>\n",
+       "      <th>seasopen</th>\n",
+       "      <th>ephopen</th>\n",
+       "      <th>saline</th>\n",
+       "      <th>lake</th>\n",
+       "      <th>seas_lake</th>\n",
+       "      <th>eph_lake</th>\n",
+       "      <th>perinuveg</th>\n",
+       "      <th>seainuveg</th>\n",
+       "      <th>ephinuveg</th>\n",
+       "      <th>agri</th>\n",
+       "      <th>reservoir</th>\n",
+       "      <th>mangrove</th>\n",
+       "      <th>mudflat</th>\n",
+       "      <th>shallow</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>adminregion_sen</td>\n",
+       "      <td>19.13</td>\n",
+       "      <td>13.39</td>\n",
+       "      <td>3.95</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>2.46</td>\n",
+       "      <td>0.42</td>\n",
+       "      <td>0.31</td>\n",
+       "      <td>1.07</td>\n",
+       "      <td>10.16</td>\n",
+       "      <td>4.70</td>\n",
+       "      <td>6.46</td>\n",
+       "      <td>0.56</td>\n",
+       "      <td>16.07</td>\n",
+       "      <td>1.98</td>\n",
+       "      <td>19.30</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>adminregion_gmb</td>\n",
+       "      <td>14.05</td>\n",
+       "      <td>3.65</td>\n",
+       "      <td>0.12</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>0.74</td>\n",
+       "      <td>14.66</td>\n",
+       "      <td>4.48</td>\n",
+       "      <td>0.76</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>22.81</td>\n",
+       "      <td>2.28</td>\n",
+       "      <td>36.36</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>adminregion_ken</td>\n",
+       "      <td>1.92</td>\n",
+       "      <td>12.09</td>\n",
+       "      <td>3.60</td>\n",
+       "      <td>34.78</td>\n",
+       "      <td>18.21</td>\n",
+       "      <td>0.22</td>\n",
+       "      <td>0.44</td>\n",
+       "      <td>0.28</td>\n",
+       "      <td>5.58</td>\n",
+       "      <td>7.57</td>\n",
+       "      <td>4.79</td>\n",
+       "      <td>0.73</td>\n",
+       "      <td>2.51</td>\n",
+       "      <td>1.39</td>\n",
+       "      <td>5.89</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>adminregion_ssd</td>\n",
+       "      <td>0.35</td>\n",
+       "      <td>3.61</td>\n",
+       "      <td>0.88</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.52</td>\n",
+       "      <td>0.09</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>1.31</td>\n",
+       "      <td>51.30</td>\n",
+       "      <td>41.33</td>\n",
+       "      <td>0.44</td>\n",
+       "      <td>0.13</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>adminregion_mrt</td>\n",
+       "      <td>3.53</td>\n",
+       "      <td>33.58</td>\n",
+       "      <td>15.20</td>\n",
+       "      <td>0.36</td>\n",
+       "      <td>0.19</td>\n",
+       "      <td>1.01</td>\n",
+       "      <td>0.13</td>\n",
+       "      <td>0.07</td>\n",
+       "      <td>13.74</td>\n",
+       "      <td>7.71</td>\n",
+       "      <td>10.52</td>\n",
+       "      <td>5.84</td>\n",
+       "      <td>0.10</td>\n",
+       "      <td>1.58</td>\n",
+       "      <td>6.46</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       location_id  permopen  seasopen  ephopen  saline   lake  seas_lake  \\\n",
+       "0  adminregion_sen     19.13     13.39     3.95    0.03   2.46       0.42   \n",
+       "1  adminregion_gmb     14.05      3.65     0.12    0.00   0.06       0.01   \n",
+       "2  adminregion_ken      1.92     12.09     3.60   34.78  18.21       0.22   \n",
+       "3  adminregion_ssd      0.35      3.61     0.88    0.00   0.52       0.09   \n",
+       "4  adminregion_mrt      3.53     33.58    15.20    0.36   0.19       1.01   \n",
+       "\n",
+       "   eph_lake  perinuveg  seainuveg  ephinuveg   agri  reservoir  mangrove  \\\n",
+       "0      0.31       1.07      10.16       4.70   6.46       0.56     16.07   \n",
+       "1      0.01       0.74      14.66       4.48   0.76       0.00     22.81   \n",
+       "2      0.44       0.28       5.58       7.57   4.79       0.73      2.51   \n",
+       "3      0.04       1.31      51.30      41.33   0.44       0.13      0.00   \n",
+       "4      0.13       0.07      13.74       7.71  10.52       5.84      0.10   \n",
+       "\n",
+       "   mudflat  shallow  \n",
+       "0     1.98    19.30  \n",
+       "1     2.28    36.36  \n",
+       "2     1.39     5.89  \n",
+       "3     0.00     0.00  \n",
+       "4     1.58     6.46  "
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#calculate percantage of each wetland type per country\n",
+    "for wetland in wetland_types:\n",
+    "    get_wetlands[wetland + '_perc'] = round(get_wetlands[wetland] / get_wetlands['total'] * 100, 2)\n",
+    "\n",
+    "get_wetlands.drop(columns= wetland_types + ['total'], inplace=True)\n",
+    "get_wetlands.columns = get_wetlands.columns.str.replace('_perc', '')\n",
+    "get_wetlands.drop(columns=['code', 'Country'], inplace=True)\n",
+    "get_wetlands.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "d8629c8d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "wetland_type",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "percentage",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "c6b99e21-765d-4578-8e0c-4cd340a03ed1",
+       "rows": [
+        [
+         "274",
+         "adminregion_ben",
+         "agri",
+         "11.95"
+        ],
+        [
+         "170",
+         "adminregion_ben",
+         "eph_lake",
+         "0.08"
+        ],
+        [
+         "248",
+         "adminregion_ben",
+         "ephinuveg",
+         "38.36"
+        ]
+       ],
+       "shape": {
+        "columns": 3,
+        "rows": 3
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>wetland_type</th>\n",
+       "      <th>percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>274</th>\n",
+       "      <td>adminregion_ben</td>\n",
+       "      <td>agri</td>\n",
+       "      <td>11.95</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>170</th>\n",
+       "      <td>adminregion_ben</td>\n",
+       "      <td>eph_lake</td>\n",
+       "      <td>0.08</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>248</th>\n",
+       "      <td>adminregion_ben</td>\n",
+       "      <td>ephinuveg</td>\n",
+       "      <td>38.36</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         location_id wetland_type  percentage\n",
+       "274  adminregion_ben         agri       11.95\n",
+       "170  adminregion_ben     eph_lake        0.08\n",
+       "248  adminregion_ben    ephinuveg       38.36"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_wetlands_long = get_wetlands.melt(id_vars=['location_id'], var_name='wetland_type', value_name='percentage')\n",
+    "get_wetlands_long.sort_values(['location_id', 'wetland_type'], inplace=True)\n",
+    "get_wetlands_long.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "1e01a7ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['agri', 'eph_lake', 'ephinuveg', 'ephopen', 'lake', 'mangrove',\n",
+       "       'mudflat', 'perinuveg', 'permopen', 'reservoir', 'saline',\n",
+       "       'seainuveg', 'seas_lake', 'seasopen', 'shallow'], dtype=object)"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_wetlands_long['wetland_type'].unique()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63747244",
+   "metadata": {},
+   "source": [
+    "## Wetland types by wdpa"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "28a139d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "permopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seasopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "saline",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seas_lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "eph_lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "perinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seainuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "agri",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "reservoir",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mangrove",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mudflat",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "shallow",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "fd8db6fb-4978-4608-aeba-e89eb014405e",
+       "rows": [
+        [
+         "0",
+         "wdpa_0",
+         "0.66",
+         "4.14",
+         "0.9",
+         "0.0",
+         "0.29",
+         "0.5",
+         "2.15",
+         "0.34",
+         "16.85",
+         "28.35",
+         "0.45",
+         "0.03",
+         "5.94",
+         "2.16",
+         "37.23"
+        ],
+        [
+         "1",
+         "wdpa_1",
+         "0.02",
+         "0.42",
+         "0.04",
+         "97.94",
+         "0.0",
+         "0.85",
+         "0.0",
+         "0.06",
+         "0.48",
+         "0.19",
+         "0.0",
+         "0.0",
+         "0.0",
+         "0.0",
+         "0.0"
+        ],
+        [
+         "2",
+         "wdpa_2",
+         "0.52",
+         "13.52",
+         "0.37",
+         "78.53",
+         "0.0",
+         "0.16",
+         "0.09",
+         "0.07",
+         "4.03",
+         "2.68",
+         "0.03",
+         "0.0",
+         "0.0",
+         "0.0",
+         "0.0"
+        ],
+        [
+         "3",
+         "wdpa_3",
+         "0.33",
+         "9.6",
+         "0.71",
+         "0.0",
+         "83.37",
+         "0.39",
+         "0.0",
+         "0.03",
+         "1.05",
+         "1.63",
+         "2.88",
+         "0.0",
+         "0.0",
+         "0.0",
+         "0.0"
+        ],
+        [
+         "4",
+         "wdpa_4",
+         "0.71",
+         "1.01",
+         "0.14",
+         "83.23",
+         "0.0",
+         "0.98",
+         "0.0",
+         "0.62",
+         "5.76",
+         "7.41",
+         "0.14",
+         "0.0",
+         "0.0",
+         "0.0",
+         "0.0"
+        ]
+       ],
+       "shape": {
+        "columns": 16,
+        "rows": 5
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>permopen</th>\n",
+       "      <th>seasopen</th>\n",
+       "      <th>ephopen</th>\n",
+       "      <th>saline</th>\n",
+       "      <th>lake</th>\n",
+       "      <th>seas_lake</th>\n",
+       "      <th>eph_lake</th>\n",
+       "      <th>perinuveg</th>\n",
+       "      <th>seainuveg</th>\n",
+       "      <th>ephinuveg</th>\n",
+       "      <th>agri</th>\n",
+       "      <th>reservoir</th>\n",
+       "      <th>mangrove</th>\n",
+       "      <th>mudflat</th>\n",
+       "      <th>shallow</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>wdpa_0</td>\n",
+       "      <td>0.66</td>\n",
+       "      <td>4.14</td>\n",
+       "      <td>0.90</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.29</td>\n",
+       "      <td>0.50</td>\n",
+       "      <td>2.15</td>\n",
+       "      <td>0.34</td>\n",
+       "      <td>16.85</td>\n",
+       "      <td>28.35</td>\n",
+       "      <td>0.45</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>5.94</td>\n",
+       "      <td>2.16</td>\n",
+       "      <td>37.23</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>wdpa_1</td>\n",
+       "      <td>0.02</td>\n",
+       "      <td>0.42</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>97.94</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.85</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.48</td>\n",
+       "      <td>0.19</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>wdpa_2</td>\n",
+       "      <td>0.52</td>\n",
+       "      <td>13.52</td>\n",
+       "      <td>0.37</td>\n",
+       "      <td>78.53</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.16</td>\n",
+       "      <td>0.09</td>\n",
+       "      <td>0.07</td>\n",
+       "      <td>4.03</td>\n",
+       "      <td>2.68</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>wdpa_3</td>\n",
+       "      <td>0.33</td>\n",
+       "      <td>9.60</td>\n",
+       "      <td>0.71</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>83.37</td>\n",
+       "      <td>0.39</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>1.05</td>\n",
+       "      <td>1.63</td>\n",
+       "      <td>2.88</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>wdpa_4</td>\n",
+       "      <td>0.71</td>\n",
+       "      <td>1.01</td>\n",
+       "      <td>0.14</td>\n",
+       "      <td>83.23</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.98</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.62</td>\n",
+       "      <td>5.76</td>\n",
+       "      <td>7.41</td>\n",
+       "      <td>0.14</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  location_id  permopen  seasopen  ephopen  saline   lake  seas_lake  \\\n",
+       "0      wdpa_0      0.66      4.14     0.90    0.00   0.29       0.50   \n",
+       "1      wdpa_1      0.02      0.42     0.04   97.94   0.00       0.85   \n",
+       "2      wdpa_2      0.52     13.52     0.37   78.53   0.00       0.16   \n",
+       "3      wdpa_3      0.33      9.60     0.71    0.00  83.37       0.39   \n",
+       "4      wdpa_4      0.71      1.01     0.14   83.23   0.00       0.98   \n",
+       "\n",
+       "   eph_lake  perinuveg  seainuveg  ephinuveg  agri  reservoir  mangrove  \\\n",
+       "0      2.15       0.34      16.85      28.35  0.45       0.03      5.94   \n",
+       "1      0.00       0.06       0.48       0.19  0.00       0.00      0.00   \n",
+       "2      0.09       0.07       4.03       2.68  0.03       0.00      0.00   \n",
+       "3      0.00       0.03       1.05       1.63  2.88       0.00      0.00   \n",
+       "4      0.00       0.62       5.76       7.41  0.14       0.00      0.00   \n",
+       "\n",
+       "   mudflat  shallow  \n",
+       "0     2.16    37.23  \n",
+       "1     0.00     0.00  \n",
+       "2     0.00     0.00  \n",
+       "3     0.00     0.00  \n",
+       "4     0.00     0.00  "
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "file_path = f'{gcs_path}/{analysis_data_folder}/wdpa_areas.csv'\n",
+    "get_wdpa = pd.read_csv(file_path)\n",
+    "#replace column names with the dictionary\n",
+    "get_wdpa = get_wdpa.rename(columns=cols_dict)\n",
+    "\n",
+    "#group categories\n",
+    "get_wdpa['seas_lake'] = get_wdpa['seas_lake'] + get_wdpa['15']\n",
+    "get_wdpa['saline'] = get_wdpa['saline'] + get_wdpa['16']\n",
+    "get_wdpa['agri'] = get_wdpa['agri'] + get_wdpa['31'] + get_wdpa['33']\n",
+    "get_wdpa['reservoir'] = get_wdpa['reservoir'] + get_wdpa['35'] + get_wdpa['36']\n",
+    "\n",
+    "get_wdpa = get_wdpa.drop(columns=['15', '16', '31', '33', '35', '36', 'other'])\n",
+    "\n",
+    "get_wdpa['total'] = get_wdpa[wetland_types].sum(axis=1)\n",
+    "\n",
+    "get_wdpa = get_wdpa.merge(locations_wpda[['name', 'id']], left_on='Country', right_on='name', how='right')\n",
+    "get_wdpa = get_wdpa.drop(columns=['name'])\n",
+    "get_wdpa.rename(columns={'id': 'location_id'}, inplace=True)\n",
+    "\n",
+    "#calculate percantage of each wetland type per country\n",
+    "for wetland in wetland_types:\n",
+    "    get_wdpa[wetland + '_perc'] = round(get_wdpa[wetland] / get_wdpa['total'] * 100, 2)\n",
+    "\n",
+    "get_wdpa.drop(columns= wetland_types + ['total'], inplace=True)\n",
+    "get_wdpa.columns = get_wdpa.columns.str.replace('_perc', '')\n",
+    "get_wdpa.drop(columns=['Country'], inplace=True)\n",
+    "\n",
+    "get_wdpa.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "75923f90",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "wetland_type",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "percentage",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "ea94612f-5c7c-4619-8728-56b043fbdd10",
+       "rows": [
+        [
+         "20240",
+         "wdpa_0",
+         "agri",
+         "0.45"
+        ],
+        [
+         "12144",
+         "wdpa_0",
+         "eph_lake",
+         "2.15"
+        ],
+        [
+         "18216",
+         "wdpa_0",
+         "ephinuveg",
+         "28.35"
+        ],
+        [
+         "4048",
+         "wdpa_0",
+         "ephopen",
+         "0.9"
+        ],
+        [
+         "8096",
+         "wdpa_0",
+         "lake",
+         "0.29"
+        ]
+       ],
+       "shape": {
+        "columns": 3,
+        "rows": 5
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>wetland_type</th>\n",
+       "      <th>percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>20240</th>\n",
+       "      <td>wdpa_0</td>\n",
+       "      <td>agri</td>\n",
+       "      <td>0.45</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12144</th>\n",
+       "      <td>wdpa_0</td>\n",
+       "      <td>eph_lake</td>\n",
+       "      <td>2.15</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18216</th>\n",
+       "      <td>wdpa_0</td>\n",
+       "      <td>ephinuveg</td>\n",
+       "      <td>28.35</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4048</th>\n",
+       "      <td>wdpa_0</td>\n",
+       "      <td>ephopen</td>\n",
+       "      <td>0.90</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8096</th>\n",
+       "      <td>wdpa_0</td>\n",
+       "      <td>lake</td>\n",
+       "      <td>0.29</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      location_id wetland_type  percentage\n",
+       "20240      wdpa_0         agri        0.45\n",
+       "12144      wdpa_0     eph_lake        2.15\n",
+       "18216      wdpa_0    ephinuveg       28.35\n",
+       "4048       wdpa_0      ephopen        0.90\n",
+       "8096       wdpa_0         lake        0.29"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_wdpa_long = get_wdpa.melt(id_vars=['location_id'], var_name='wetland_type', value_name='percentage')\n",
+    "get_wdpa_long.sort_values(['location_id', 'wetland_type'], inplace=True)\n",
+    "get_wdpa_long.head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be1798d5",
+   "metadata": {},
+   "source": [
+    "## Wetland types by hydrobasin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "9bc60217",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "permopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seasopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "saline",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seas_lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "eph_lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "perinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seainuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "agri",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "reservoir",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mangrove",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mudflat",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "shallow",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "1b9aafb9-5869-47f8-916e-0665f9a351b3",
+       "rows": [
+        [
+         "0",
+         "hydrobasin_red_sea_basin",
+         "2.68",
+         "22.8",
+         "4.75",
+         "0.05",
+         "0.04",
+         "3.46",
+         "0.28",
+         "0.01",
+         "3.43",
+         "2.43",
+         "0.09",
+         "3.12",
+         "2.87",
+         "18.17",
+         "35.8"
+        ],
+        [
+         "1",
+         "hydrobasin_horn_of_africa_basin",
+         "65.56",
+         "20.23",
+         "0.84",
+         "0.0",
+         "0.0",
+         "0.0",
+         "0.02",
+         "0.0",
+         "0.35",
+         "0.4",
+         "0.01",
+         "0.01",
+         "1.24",
+         "2.21",
+         "9.13"
+        ],
+        [
+         "2",
+         "hydrobasin_juba_shibeli_basin",
+         "3.25",
+         "30.08",
+         "14.22",
+         "0.04",
+         "0.05",
+         "0.18",
+         "1.47",
+         "0.86",
+         "14.36",
+         "22.65",
+         "8.38",
+         "4.46",
+         "0.0",
+         "0.0",
+         "0.0"
+        ],
+        [
+         "3",
+         "hydrobasin_tana_basin",
+         "2.8",
+         "9.04",
+         "5.12",
+         "0.08",
+         "1.07",
+         "0.31",
+         "0.33",
+         "0.63",
+         "11.92",
+         "22.26",
+         "17.54",
+         "3.64",
+         "15.41",
+         "5.26",
+         "4.6"
+        ],
+        [
+         "4",
+         "hydrobasin_congo_basin",
+         "5.86",
+         "1.11",
+         "1.14",
+         "0.0",
+         "0.0",
+         "0.0",
+         "0.15",
+         "5.76",
+         "26.06",
+         "59.6",
+         "0.32",
+         "0.0",
+         "0.0",
+         "0.0",
+         "0.0"
+        ]
+       ],
+       "shape": {
+        "columns": 16,
+        "rows": 5
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>permopen</th>\n",
+       "      <th>seasopen</th>\n",
+       "      <th>ephopen</th>\n",
+       "      <th>saline</th>\n",
+       "      <th>lake</th>\n",
+       "      <th>seas_lake</th>\n",
+       "      <th>eph_lake</th>\n",
+       "      <th>perinuveg</th>\n",
+       "      <th>seainuveg</th>\n",
+       "      <th>ephinuveg</th>\n",
+       "      <th>agri</th>\n",
+       "      <th>reservoir</th>\n",
+       "      <th>mangrove</th>\n",
+       "      <th>mudflat</th>\n",
+       "      <th>shallow</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>hydrobasin_red_sea_basin</td>\n",
+       "      <td>2.68</td>\n",
+       "      <td>22.80</td>\n",
+       "      <td>4.75</td>\n",
+       "      <td>0.05</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>3.46</td>\n",
+       "      <td>0.28</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>3.43</td>\n",
+       "      <td>2.43</td>\n",
+       "      <td>0.09</td>\n",
+       "      <td>3.12</td>\n",
+       "      <td>2.87</td>\n",
+       "      <td>18.17</td>\n",
+       "      <td>35.80</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>hydrobasin_horn_of_africa_basin</td>\n",
+       "      <td>65.56</td>\n",
+       "      <td>20.23</td>\n",
+       "      <td>0.84</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.02</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.35</td>\n",
+       "      <td>0.40</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>1.24</td>\n",
+       "      <td>2.21</td>\n",
+       "      <td>9.13</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>hydrobasin_juba_shibeli_basin</td>\n",
+       "      <td>3.25</td>\n",
+       "      <td>30.08</td>\n",
+       "      <td>14.22</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>0.05</td>\n",
+       "      <td>0.18</td>\n",
+       "      <td>1.47</td>\n",
+       "      <td>0.86</td>\n",
+       "      <td>14.36</td>\n",
+       "      <td>22.65</td>\n",
+       "      <td>8.38</td>\n",
+       "      <td>4.46</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>hydrobasin_tana_basin</td>\n",
+       "      <td>2.80</td>\n",
+       "      <td>9.04</td>\n",
+       "      <td>5.12</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>1.07</td>\n",
+       "      <td>0.31</td>\n",
+       "      <td>0.33</td>\n",
+       "      <td>0.63</td>\n",
+       "      <td>11.92</td>\n",
+       "      <td>22.26</td>\n",
+       "      <td>17.54</td>\n",
+       "      <td>3.64</td>\n",
+       "      <td>15.41</td>\n",
+       "      <td>5.26</td>\n",
+       "      <td>4.60</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>hydrobasin_congo_basin</td>\n",
+       "      <td>5.86</td>\n",
+       "      <td>1.11</td>\n",
+       "      <td>1.14</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.15</td>\n",
+       "      <td>5.76</td>\n",
+       "      <td>26.06</td>\n",
+       "      <td>59.60</td>\n",
+       "      <td>0.32</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                       location_id  permopen  seasopen  ephopen  saline  lake  \\\n",
+       "0         hydrobasin_red_sea_basin      2.68     22.80     4.75    0.05  0.04   \n",
+       "1  hydrobasin_horn_of_africa_basin     65.56     20.23     0.84    0.00  0.00   \n",
+       "2    hydrobasin_juba_shibeli_basin      3.25     30.08    14.22    0.04  0.05   \n",
+       "3            hydrobasin_tana_basin      2.80      9.04     5.12    0.08  1.07   \n",
+       "4           hydrobasin_congo_basin      5.86      1.11     1.14    0.00  0.00   \n",
+       "\n",
+       "   seas_lake  eph_lake  perinuveg  seainuveg  ephinuveg   agri  reservoir  \\\n",
+       "0       3.46      0.28       0.01       3.43       2.43   0.09       3.12   \n",
+       "1       0.00      0.02       0.00       0.35       0.40   0.01       0.01   \n",
+       "2       0.18      1.47       0.86      14.36      22.65   8.38       4.46   \n",
+       "3       0.31      0.33       0.63      11.92      22.26  17.54       3.64   \n",
+       "4       0.00      0.15       5.76      26.06      59.60   0.32       0.00   \n",
+       "\n",
+       "   mangrove  mudflat  shallow  \n",
+       "0      2.87    18.17    35.80  \n",
+       "1      1.24     2.21     9.13  \n",
+       "2      0.00     0.00     0.00  \n",
+       "3     15.41     5.26     4.60  \n",
+       "4      0.00     0.00     0.00  "
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "file_path = f'{gcs_path}/{analysis_data_folder}/hydro_basin_areas.csv'\n",
+    "get_hydrobasins = pd.read_csv(file_path)\n",
+    "#replace column names with the dictionary\n",
+    "get_hydrobasins = get_hydrobasins.rename(columns=cols_dict)\n",
+    "\n",
+    "#group categories\n",
+    "get_hydrobasins['seas_lake'] = get_hydrobasins['seas_lake'] + get_hydrobasins['15']\n",
+    "get_hydrobasins['saline'] = get_hydrobasins['saline'] + get_hydrobasins['16']\n",
+    "get_hydrobasins['agri'] = get_hydrobasins['agri'] + get_hydrobasins['31'] + get_hydrobasins['33']\n",
+    "get_hydrobasins['reservoir'] = get_hydrobasins['reservoir'] + get_hydrobasins['35'] + get_hydrobasins['36']\n",
+    "\n",
+    "get_hydrobasins = get_hydrobasins.drop(columns=['15', '16', '31', '33', '35', '36', 'other'])\n",
+    "\n",
+    "get_hydrobasins['total'] = get_hydrobasins[wetland_types].sum(axis=1)\n",
+    "get_hydrobasins['basin_name'] = get_hydrobasins['Country'] + ' Basin'\n",
+    "\n",
+    "get_hydrobasins = get_hydrobasins.merge(locations_basins[['name', 'id']], left_on='basin_name', right_on='name', how='right')\n",
+    "get_hydrobasins = get_hydrobasins.drop(columns=['name', 'basin_name'])\n",
+    "get_hydrobasins.rename(columns={'id': 'location_id'}, inplace=True)\n",
+    "\n",
+    "#calculate percantage of each wetland type per country\n",
+    "for wetland in wetland_types:\n",
+    "    get_hydrobasins[wetland + '_perc'] = round(get_hydrobasins[wetland] / get_hydrobasins['total'] * 100, 2)\n",
+    "\n",
+    "get_hydrobasins.drop(columns= wetland_types + ['total'], inplace=True)\n",
+    "get_hydrobasins.columns = get_hydrobasins.columns.str.replace('_perc', '')\n",
+    "get_hydrobasins.drop(columns=['Country'], inplace=True)\n",
+    "\n",
+    "get_hydrobasins.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "b8eee9da",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "wetland_type",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "percentage",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "90e4bb0c-048d-4e42-bdbf-66289669b7e4",
+       "rows": [
+        [
+         "174",
+         "hydrobasin_congo_basin",
+         "agri",
+         "0.32"
+        ],
+        [
+         "106",
+         "hydrobasin_congo_basin",
+         "eph_lake",
+         "0.15"
+        ],
+        [
+         "157",
+         "hydrobasin_congo_basin",
+         "ephinuveg",
+         "59.6"
+        ],
+        [
+         "38",
+         "hydrobasin_congo_basin",
+         "ephopen",
+         "1.14"
+        ],
+        [
+         "72",
+         "hydrobasin_congo_basin",
+         "lake",
+         "0.0"
+        ]
+       ],
+       "shape": {
+        "columns": 3,
+        "rows": 5
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>wetland_type</th>\n",
+       "      <th>percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>174</th>\n",
+       "      <td>hydrobasin_congo_basin</td>\n",
+       "      <td>agri</td>\n",
+       "      <td>0.32</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>106</th>\n",
+       "      <td>hydrobasin_congo_basin</td>\n",
+       "      <td>eph_lake</td>\n",
+       "      <td>0.15</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>157</th>\n",
+       "      <td>hydrobasin_congo_basin</td>\n",
+       "      <td>ephinuveg</td>\n",
+       "      <td>59.60</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38</th>\n",
+       "      <td>hydrobasin_congo_basin</td>\n",
+       "      <td>ephopen</td>\n",
+       "      <td>1.14</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>72</th>\n",
+       "      <td>hydrobasin_congo_basin</td>\n",
+       "      <td>lake</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                location_id wetland_type  percentage\n",
+       "174  hydrobasin_congo_basin         agri        0.32\n",
+       "106  hydrobasin_congo_basin     eph_lake        0.15\n",
+       "157  hydrobasin_congo_basin    ephinuveg       59.60\n",
+       "38   hydrobasin_congo_basin      ephopen        1.14\n",
+       "72   hydrobasin_congo_basin         lake        0.00"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_hydrobasins_long = get_hydrobasins.melt(id_vars=['location_id'], var_name='wetland_type', value_name='percentage')\n",
+    "get_hydrobasins_long.sort_values(['location_id', 'wetland_type'], inplace=True)\n",
+    "get_hydrobasins_long.head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e66cc24d",
+   "metadata": {},
+   "source": [
+    "## Wetland types Sahel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "4e89f59a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "permopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seasopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephopen",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "saline",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seas_lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "eph_lake",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "perinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "seainuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "ephinuveg",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "agri",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "reservoir",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mangrove",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mudflat",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "shallow",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "6dda7f2f-5472-46d0-ac19-65106a293f7e",
+       "rows": [
+        [
+         "0",
+         "global_sahel",
+         "2.59",
+         "8.54",
+         "2.84",
+         "2.16",
+         "3.57",
+         "1.17",
+         "0.11",
+         "0.63",
+         "31.65",
+         "26.0",
+         "13.61",
+         "3.3",
+         "1.02",
+         "0.26",
+         "2.54"
+        ]
+       ],
+       "shape": {
+        "columns": 16,
+        "rows": 1
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>permopen</th>\n",
+       "      <th>seasopen</th>\n",
+       "      <th>ephopen</th>\n",
+       "      <th>saline</th>\n",
+       "      <th>lake</th>\n",
+       "      <th>seas_lake</th>\n",
+       "      <th>eph_lake</th>\n",
+       "      <th>perinuveg</th>\n",
+       "      <th>seainuveg</th>\n",
+       "      <th>ephinuveg</th>\n",
+       "      <th>agri</th>\n",
+       "      <th>reservoir</th>\n",
+       "      <th>mangrove</th>\n",
+       "      <th>mudflat</th>\n",
+       "      <th>shallow</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>global_sahel</td>\n",
+       "      <td>2.59</td>\n",
+       "      <td>8.54</td>\n",
+       "      <td>2.84</td>\n",
+       "      <td>2.16</td>\n",
+       "      <td>3.57</td>\n",
+       "      <td>1.17</td>\n",
+       "      <td>0.11</td>\n",
+       "      <td>0.63</td>\n",
+       "      <td>31.65</td>\n",
+       "      <td>26.0</td>\n",
+       "      <td>13.61</td>\n",
+       "      <td>3.3</td>\n",
+       "      <td>1.02</td>\n",
+       "      <td>0.26</td>\n",
+       "      <td>2.54</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    location_id  permopen  seasopen  ephopen  saline  lake  seas_lake  \\\n",
+       "0  global_sahel      2.59      8.54     2.84    2.16  3.57       1.17   \n",
+       "\n",
+       "   eph_lake  perinuveg  seainuveg  ephinuveg   agri  reservoir  mangrove  \\\n",
+       "0      0.11       0.63      31.65       26.0  13.61        3.3      1.02   \n",
+       "\n",
+       "   mudflat  shallow  \n",
+       "0     0.26     2.54  "
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "file_path = f'{gcs_path}/{analysis_data_folder}/global_areas.csv'\n",
+    "get_sahel = pd.read_csv(file_path)\n",
+    "#replace column names with the dictionary\n",
+    "get_sahel = get_sahel.rename(columns=cols_dict)\n",
+    "\n",
+    "#group categories\n",
+    "get_sahel['seas_lake'] = get_sahel['seas_lake'] + get_sahel['15']\n",
+    "get_sahel['saline'] = get_sahel['saline'] + get_sahel['16']\n",
+    "get_sahel['agri'] = get_sahel['agri'] + get_sahel['31'] + get_sahel['33']\n",
+    "get_sahel['reservoir'] = get_sahel['reservoir'] + get_sahel['35'] + get_sahel['36']\n",
+    "\n",
+    "get_sahel = get_sahel.drop(columns=['15', '16', '31', '33', '35', '36', 'other'])\n",
+    "\n",
+    "get_sahel['total'] = get_sahel[wetland_types].sum(axis=1)\n",
+    "\n",
+    "get_sahel['location_id'] = 'global_sahel'\n",
+    "\n",
+    "\n",
+    "\n",
+    "#calculate percantage of each wetland type per country\n",
+    "for wetland in wetland_types:\n",
+    "    get_sahel[wetland + '_perc'] = round(get_sahel[wetland] / get_sahel['total'] * 100, 2)\n",
+    "\n",
+    "get_sahel.drop(columns= wetland_types + ['total'], inplace=True)\n",
+    "get_sahel.columns = get_sahel.columns.str.replace('_perc', '')\n",
+    "get_sahel.drop(columns=['Country'], inplace=True)\n",
+    "get_sahel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "dd957e4c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "location_id",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "wetland_type",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "percentage",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "ref": "aafda2ee-3f87-404b-84e2-caf50a0f8e18",
+       "rows": [
+        [
+         "10",
+         "global_sahel",
+         "agri",
+         "13.61"
+        ],
+        [
+         "6",
+         "global_sahel",
+         "eph_lake",
+         "0.11"
+        ],
+        [
+         "9",
+         "global_sahel",
+         "ephinuveg",
+         "26.0"
+        ],
+        [
+         "2",
+         "global_sahel",
+         "ephopen",
+         "2.84"
+        ],
+        [
+         "4",
+         "global_sahel",
+         "lake",
+         "3.57"
+        ]
+       ],
+       "shape": {
+        "columns": 3,
+        "rows": 5
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>wetland_type</th>\n",
+       "      <th>percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>global_sahel</td>\n",
+       "      <td>agri</td>\n",
+       "      <td>13.61</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>global_sahel</td>\n",
+       "      <td>eph_lake</td>\n",
+       "      <td>0.11</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>global_sahel</td>\n",
+       "      <td>ephinuveg</td>\n",
+       "      <td>26.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>global_sahel</td>\n",
+       "      <td>ephopen</td>\n",
+       "      <td>2.84</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>global_sahel</td>\n",
+       "      <td>lake</td>\n",
+       "      <td>3.57</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     location_id wetland_type  percentage\n",
+       "10  global_sahel         agri       13.61\n",
+       "6   global_sahel     eph_lake        0.11\n",
+       "9   global_sahel    ephinuveg       26.00\n",
+       "2   global_sahel      ephopen        2.84\n",
+       "4   global_sahel         lake        3.57"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_sahel_long = get_sahel.melt(id_vars=['location_id'], var_name='wetland_type', value_name='percentage')\n",
+    "get_sahel_long.sort_values(['location_id', 'wetland_type'], inplace=True)\n",
+    "get_sahel_long.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "20a2666b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "15\n",
+      "15\n",
+      "15\n",
+      "15\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(len(get_wetlands_long['wetland_type'].unique()))\n",
+    "print(len(get_wdpa_long['wetland_type'].unique()))\n",
+    "print(len(get_hydrobasins_long['wetland_type'].unique()))\n",
+    "print(len(get_sahel_long['wetland_type'].unique()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f179e64",
+   "metadata": {},
+   "source": [
+    "## Combine all data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "547fbe32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_combined = pd.concat([get_wetlands_long, get_wdpa_long, get_hydrobasins_long, get_sahel_long], ignore_index=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "id": "b33eaeca",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "15\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array(['agri', 'eph_lake', 'ephinuveg', 'ephopen', 'lake', 'mangrove',\n",
+       "       'mudflat', 'perinuveg', 'permopen', 'reservoir', 'saline',\n",
+       "       'seainuveg', 'seas_lake', 'seasopen', 'shallow'], dtype=object)"
+      ]
+     },
+     "execution_count": 68,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(len(get_combined['wetland_type'].unique()))\n",
+    "get_combined['wetland_type'].unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "95f48f84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Replace Na with 0\n",
+    "get_combined['percentage'] = get_combined['percentage'].replace(np.nan, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "0a22507e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "color_dict = {'agri':\"#ff9067\",\n",
+    "              'eph_lake': \"#9499ff\",\n",
+    "              'ephinuveg': \"#9ec59e\",\n",
+    "              'ephopen': \"#f6ffff\",\n",
+    "              'lake': \"#000dff\",\n",
+    "              'mangrove': \"#663399\",\n",
+    "              'mudflat': \"#a0522d\",\n",
+    "              'perinuveg': \"#006400\",\n",
+    "              'permopen': \"#7acaff\",\n",
+    "              'reservoir': \"#56b98b\",\n",
+    "              'saline': \"#cfe875\",\n",
+    "              'seainuveg': \"#8bc500\",\n",
+    "              'seas_lake': \"#4747ff\",\n",
+    "              'seasopen': \"#e2ffff\",\n",
+    "              'shallow': \"#ccffdf\",}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "142b4b61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indicator_data_list = []\n",
+    "\n",
+    "for location in get_combined['location_id'].unique():\n",
+    "    df_location = get_combined[get_combined['location_id'] == location]\n",
+    "    df_location.reset_index(drop=True, inplace=True)\n",
+    "    data_list = []\n",
+    "    for i in range(len(df_location)):\n",
+    "        data_list.append({\n",
+    "            \"id\":\"wetland_type_\" + location + \"_\" + str(i),\n",
+    "            \"label\": df_location.loc[i, 'wetland_type'],\n",
+    "            \"value\": df_location.loc[i, 'percentage'],\n",
+    "            \"type\":\"\",\n",
+    "            \"group\": \"\",\n",
+    "            \"color\": color_dict.get(df_location.loc[i, 'wetland_type'], \"#000000\"),\n",
+    "            \"format\": \"number\",\n",
+    "            \"unit\": \"%\"\n",
+    "        })\n",
+    "    data_json = json.dumps(data_list, indent=2)\n",
+    "    temp_dict = {\"id\": \"wetland-types-\" + location,\n",
+    "                 \"location\": location,\n",
+    "                 \"indicator\": \"wetland-types-get\",\n",
+    "                 \"data\": json.loads(data_json),\n",
+    "                 \"locale\": {\"en\": {\"labels\":{\n",
+    "                     'agri':'Agriculture',\n",
+    "                     'eph_lake':'Ephemeral Lake',\n",
+    "                     'ephinuveg':'Ephemeral Inundated Vegetation',\n",
+    "                     'ephopen':'Ephemeral Open Water',\n",
+    "                     'lake':'Lake',\n",
+    "                     'mangrove':'Mangrove',\n",
+    "                     'mudflat':'Mudflat',\n",
+    "                     'perinuveg':'Permanently Inundated Vegetation',\n",
+    "                     'permopen':'Permanent Open Water',\n",
+    "                     'reservoir':'Reservoir',\n",
+    "                     'saline':'Saline',\n",
+    "                     'seainuveg':'Seasonally Inundated Vegetation',\n",
+    "                     'seas_lake':'Seasonal Lake',\n",
+    "                     'seasopen':'Seasonal Open Water',\n",
+    "                     'shallow':'Shallow Coast'\n",
+    "                    }\n",
+    "                    }},\n",
+    "                }\n",
+    "    indicator_data_list.append(temp_dict)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "id": "ae523e53",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"id\": \"wetland-types-adminregion_ben\",\n",
+      "  \"location\": \"adminregion_ben\",\n",
+      "  \"indicator\": \"wetland-types-get\",\n",
+      "  \"data\": [\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_0\",\n",
+      "      \"label\": \"agri\",\n",
+      "      \"value\": 11.95,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#ff9067\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_1\",\n",
+      "      \"label\": \"eph_lake\",\n",
+      "      \"value\": 0.08,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#9499ff\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_2\",\n",
+      "      \"label\": \"ephinuveg\",\n",
+      "      \"value\": 38.36,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#9ec59e\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_3\",\n",
+      "      \"label\": \"ephopen\",\n",
+      "      \"value\": 3.18,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#f6ffff\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_4\",\n",
+      "      \"label\": \"lake\",\n",
+      "      \"value\": 0.0,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#000dff\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_5\",\n",
+      "      \"label\": \"mangrove\",\n",
+      "      \"value\": 0.0,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#663399\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_6\",\n",
+      "      \"label\": \"mudflat\",\n",
+      "      \"value\": 0.0,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#a0522d\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_7\",\n",
+      "      \"label\": \"perinuveg\",\n",
+      "      \"value\": 0.16,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#006400\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_8\",\n",
+      "      \"label\": \"permopen\",\n",
+      "      \"value\": 2.48,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#7acaff\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_9\",\n",
+      "      \"label\": \"reservoir\",\n",
+      "      \"value\": 0.36,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#56b98b\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_10\",\n",
+      "      \"label\": \"saline\",\n",
+      "      \"value\": 0.01,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#cfe875\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_11\",\n",
+      "      \"label\": \"seainuveg\",\n",
+      "      \"value\": 33.48,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#8bc500\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_12\",\n",
+      "      \"label\": \"seas_lake\",\n",
+      "      \"value\": 1.13,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#4747ff\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_13\",\n",
+      "      \"label\": \"seasopen\",\n",
+      "      \"value\": 8.81,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#e2ffff\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_14\",\n",
+      "      \"label\": \"shallow\",\n",
+      "      \"value\": 0.0,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#ccffdf\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    }\n",
+      "  ],\n",
+      "  \"locale\": {\n",
+      "    \"en\": {\n",
+      "      \"labels\": {\n",
+      "        \"agri\": \"Agriculture\",\n",
+      "        \"eph_lake\": \"Ephemeral Lake\",\n",
+      "        \"ephinuveg\": \"Ephemeral Inundated Vegetation\",\n",
+      "        \"ephopen\": \"Ephemeral Open Water\",\n",
+      "        \"lake\": \"Lake\",\n",
+      "        \"mangrove\": \"Mangrove\",\n",
+      "        \"mudflat\": \"Mudflat\",\n",
+      "        \"perinuveg\": \"Permanently Inundated Vegetation\",\n",
+      "        \"permopen\": \"Permanent Open Water\",\n",
+      "        \"reservoir\": \"Reservoir\",\n",
+      "        \"saline\": \"Saline\",\n",
+      "        \"seainuveg\": \"Seasonally Inundated Vegetation\",\n",
+      "        \"seas_lake\": \"Seasonal Lake\",\n",
+      "        \"seasopen\": \"Seasonal Open Water\",\n",
+      "        \"shallow\": \"Shallow Coast\"\n",
+      "      }\n",
+      "    }\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(json.dumps(indicator_data_list[0], indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8eba2821",
+   "metadata": {},
+   "source": [
+    "### Save to json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "id": "48a1254d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seeding_json = json.load(open('../../app-initial-data/indicator-data.json'))\n",
+    "#remove all entries with id that starts with \"wetland-types-\" and \"wetland_types_\"\n",
+    "seeding_json = [entry for entry in seeding_json if not entry['id'].startswith('wetland-types-') and not entry['id'].startswith('wetland_types_')]\n",
+    "\n",
+    "# Append the new data, if id exists update it\n",
+    "existing_ids = {entry['id'] for entry in seeding_json}\n",
+    "for new_entry in indicator_data_list:\n",
+    "    if new_entry['id'] in existing_ids:\n",
+    "        seeding_json = [entry if entry['id'] != new_entry['id'] else new_entry for entry in seeding_json]\n",
+    "    else:\n",
+    "        seeding_json.append(new_entry)  \n",
+    "with open('../../app-initial-data/indicator-data.json', 'w') as f:\n",
+    "    json.dump(seeding_json, f, indent=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20861fbd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pyFIP",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/data-processing/notebooks/07a_UPDATED_wetlands_inventory_data.ipynb
+++ b/data-processing/notebooks/07a_UPDATED_wetlands_inventory_data.ipynb
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 74,
    "id": "42a90c06",
    "metadata": {},
    "outputs": [],
@@ -80,11 +80,10 @@
     "    '41': 'mangrove',\n",
     "    '42': 'mudflat',\n",
     "    '128': 'shallow',\n",
-    "    '43': 'other'\n",
+    "    '43': 'saltmarsh',\n",
     "}\n",
     "\n",
-    "wetland_types = list(cols_dict.values())\n",
-    "wetland_types.remove('other')"
+    "wetland_types = list(cols_dict.values())\n"
    ]
   },
   {
@@ -97,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 75,
    "id": "77cbabb9",
    "metadata": {},
    "outputs": [
@@ -186,6 +185,11 @@
          "type": "float"
         },
         {
+         "name": "saltmarsh",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
          "name": "shallow",
          "rawType": "float64",
          "type": "float"
@@ -206,7 +210,7 @@
          "type": "string"
         }
        ],
-       "ref": "d61ef89b-13a8-46c8-b52a-20ede0265dd7",
+       "ref": "2df34df2-520c-44f8-9794-9417f8911ea7",
        "rows": [
         [
          "0",
@@ -225,8 +229,9 @@
          "5989.860000000001",
          "172101.24",
          "21246.93",
+         "5074.29",
          "206759.79",
-         "1071141.12",
+         "1076215.4100000001",
          "SEN",
          "adminregion_sen"
         ],
@@ -247,8 +252,9 @@
          "0.27",
          "78100.29",
          "7791.66",
+         "2992.86",
          "124499.16",
-         "342442.62",
+         "345435.48",
          "GMB",
          "adminregion_gmb"
         ],
@@ -269,8 +275,9 @@
          "15802.47",
          "54379.71",
          "30144.96",
+         "107.1",
          "127666.26",
-         "2168601.12",
+         "2168708.22",
          "KEN",
          "adminregion_ken"
         ],
@@ -289,6 +296,7 @@
          "5646269.7",
          "60432.03",
          "17975.34",
+         "0.0",
          "0.0",
          "0.0",
          "0.0",
@@ -313,14 +321,15 @@
          "18068.94",
          "310.41",
          "4885.74",
+         "2788.11",
          "19967.04",
-         "309207.05999999994",
+         "311995.1699999999",
          "MRT",
          "adminregion_mrt"
         ]
        ],
        "shape": {
-        "columns": 19,
+        "columns": 20,
         "rows": 5
        }
       },
@@ -358,6 +367,7 @@
        "      <th>reservoir</th>\n",
        "      <th>mangrove</th>\n",
        "      <th>mudflat</th>\n",
+       "      <th>saltmarsh</th>\n",
        "      <th>shallow</th>\n",
        "      <th>total</th>\n",
        "      <th>code</th>\n",
@@ -382,8 +392,9 @@
        "      <td>5989.86</td>\n",
        "      <td>172101.24</td>\n",
        "      <td>21246.93</td>\n",
+       "      <td>5074.29</td>\n",
        "      <td>206759.79</td>\n",
-       "      <td>1071141.12</td>\n",
+       "      <td>1076215.41</td>\n",
        "      <td>SEN</td>\n",
        "      <td>adminregion_sen</td>\n",
        "    </tr>\n",
@@ -404,8 +415,9 @@
        "      <td>0.27</td>\n",
        "      <td>78100.29</td>\n",
        "      <td>7791.66</td>\n",
+       "      <td>2992.86</td>\n",
        "      <td>124499.16</td>\n",
-       "      <td>342442.62</td>\n",
+       "      <td>345435.48</td>\n",
        "      <td>GMB</td>\n",
        "      <td>adminregion_gmb</td>\n",
        "    </tr>\n",
@@ -426,8 +438,9 @@
        "      <td>15802.47</td>\n",
        "      <td>54379.71</td>\n",
        "      <td>30144.96</td>\n",
+       "      <td>107.10</td>\n",
        "      <td>127666.26</td>\n",
-       "      <td>2168601.12</td>\n",
+       "      <td>2168708.22</td>\n",
        "      <td>KEN</td>\n",
        "      <td>adminregion_ken</td>\n",
        "    </tr>\n",
@@ -446,6 +459,7 @@
        "      <td>5646269.70</td>\n",
        "      <td>60432.03</td>\n",
        "      <td>17975.34</td>\n",
+       "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
@@ -470,8 +484,9 @@
        "      <td>18068.94</td>\n",
        "      <td>310.41</td>\n",
        "      <td>4885.74</td>\n",
+       "      <td>2788.11</td>\n",
        "      <td>19967.04</td>\n",
-       "      <td>309207.06</td>\n",
+       "      <td>311995.17</td>\n",
        "      <td>MRT</td>\n",
        "      <td>adminregion_mrt</td>\n",
        "    </tr>\n",
@@ -494,12 +509,12 @@
        "3   11616.66   6103.17  178421.67  7008218.37  5646269.70   60432.03   \n",
        "4    3114.27    393.12     224.73    42477.30    23834.07   32530.86   \n",
        "\n",
-       "   reservoir   mangrove   mudflat    shallow        total code  \\\n",
-       "0    5989.86  172101.24  21246.93  206759.79   1071141.12  SEN   \n",
-       "1       0.27   78100.29   7791.66  124499.16    342442.62  GMB   \n",
-       "2   15802.47   54379.71  30144.96  127666.26   2168601.12  KEN   \n",
-       "3   17975.34       0.00      0.00       0.00  13661521.29  SSD   \n",
-       "4   18068.94     310.41   4885.74   19967.04    309207.06  MRT   \n",
+       "   reservoir   mangrove   mudflat  saltmarsh    shallow        total code  \\\n",
+       "0    5989.86  172101.24  21246.93    5074.29  206759.79   1076215.41  SEN   \n",
+       "1       0.27   78100.29   7791.66    2992.86  124499.16    345435.48  GMB   \n",
+       "2   15802.47   54379.71  30144.96     107.10  127666.26   2168708.22  KEN   \n",
+       "3   17975.34       0.00      0.00       0.00       0.00  13661521.29  SSD   \n",
+       "4   18068.94     310.41   4885.74    2788.11   19967.04    311995.17  MRT   \n",
        "\n",
        "       location_id  \n",
        "0  adminregion_sen  \n",
@@ -509,7 +524,7 @@
        "4  adminregion_mrt  "
       ]
      },
-     "execution_count": 39,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -526,7 +541,7 @@
     "get_wetlands['agri'] = get_wetlands['agri'] + get_wetlands['31'] + get_wetlands['33']\n",
     "get_wetlands['reservoir'] = get_wetlands['reservoir'] + get_wetlands['35'] + get_wetlands['36']\n",
     "\n",
-    "get_wetlands = get_wetlands.drop(columns=['15', '16', '31', '33', '35', '36', 'other'])\n",
+    "get_wetlands = get_wetlands.drop(columns=['15', '16', '31', '33', '35', '36'])\n",
     "\n",
     "get_wetlands['total'] = get_wetlands[wetland_types].sum(axis=1)\n",
     "\n",
@@ -542,7 +557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 76,
    "id": "7407892b",
    "metadata": {},
    "outputs": [
@@ -634,47 +649,54 @@
          "name": "shallow",
          "rawType": "float64",
          "type": "float"
+        },
+        {
+         "name": "saltmarsh",
+         "rawType": "float64",
+         "type": "float"
         }
        ],
-       "ref": "cb266cc7-34a9-4e0e-a777-947ff5fab6f7",
+       "ref": "acb89971-8ad4-40a9-8cce-eba82733b29f",
        "rows": [
         [
          "0",
          "adminregion_sen",
-         "19.13",
-         "13.39",
-         "3.95",
+         "19.04",
+         "13.33",
+         "3.94",
          "0.03",
-         "2.46",
+         "2.45",
          "0.42",
          "0.31",
-         "1.07",
-         "10.16",
-         "4.7",
-         "6.46",
+         "1.06",
+         "10.11",
+         "4.67",
+         "6.43",
          "0.56",
-         "16.07",
-         "1.98",
-         "19.3"
+         "15.99",
+         "1.97",
+         "19.21",
+         "0.47"
         ],
         [
          "1",
          "adminregion_gmb",
-         "14.05",
-         "3.65",
+         "13.93",
+         "3.62",
          "0.12",
          "0.0",
          "0.06",
          "0.01",
          "0.01",
          "0.74",
-         "14.66",
-         "4.48",
-         "0.76",
+         "14.53",
+         "4.45",
+         "0.75",
          "0.0",
-         "22.81",
-         "2.28",
-         "36.36"
+         "22.61",
+         "2.26",
+         "36.04",
+         "0.87"
         ],
         [
          "2",
@@ -693,7 +715,8 @@
          "0.73",
          "2.51",
          "1.39",
-         "5.89"
+         "5.89",
+         "0.0"
         ],
         [
          "3",
@@ -712,30 +735,32 @@
          "0.13",
          "0.0",
          "0.0",
+         "0.0",
          "0.0"
         ],
         [
          "4",
          "adminregion_mrt",
-         "3.53",
-         "33.58",
-         "15.2",
-         "0.36",
-         "0.19",
-         "1.01",
+         "3.5",
+         "33.28",
+         "15.06",
+         "0.35",
+         "0.18",
+         "1.0",
          "0.13",
          "0.07",
-         "13.74",
-         "7.71",
-         "10.52",
-         "5.84",
+         "13.61",
+         "7.64",
+         "10.43",
+         "5.79",
          "0.1",
-         "1.58",
-         "6.46"
+         "1.57",
+         "6.4",
+         "0.89"
         ]
        ],
        "shape": {
-        "columns": 16,
+        "columns": 17,
         "rows": 5
        }
       },
@@ -774,46 +799,49 @@
        "      <th>mangrove</th>\n",
        "      <th>mudflat</th>\n",
        "      <th>shallow</th>\n",
+       "      <th>saltmarsh</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>adminregion_sen</td>\n",
-       "      <td>19.13</td>\n",
-       "      <td>13.39</td>\n",
-       "      <td>3.95</td>\n",
+       "      <td>19.04</td>\n",
+       "      <td>13.33</td>\n",
+       "      <td>3.94</td>\n",
        "      <td>0.03</td>\n",
-       "      <td>2.46</td>\n",
+       "      <td>2.45</td>\n",
        "      <td>0.42</td>\n",
        "      <td>0.31</td>\n",
-       "      <td>1.07</td>\n",
-       "      <td>10.16</td>\n",
-       "      <td>4.70</td>\n",
-       "      <td>6.46</td>\n",
+       "      <td>1.06</td>\n",
+       "      <td>10.11</td>\n",
+       "      <td>4.67</td>\n",
+       "      <td>6.43</td>\n",
        "      <td>0.56</td>\n",
-       "      <td>16.07</td>\n",
-       "      <td>1.98</td>\n",
-       "      <td>19.30</td>\n",
+       "      <td>15.99</td>\n",
+       "      <td>1.97</td>\n",
+       "      <td>19.21</td>\n",
+       "      <td>0.47</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>adminregion_gmb</td>\n",
-       "      <td>14.05</td>\n",
-       "      <td>3.65</td>\n",
+       "      <td>13.93</td>\n",
+       "      <td>3.62</td>\n",
        "      <td>0.12</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.06</td>\n",
        "      <td>0.01</td>\n",
        "      <td>0.01</td>\n",
        "      <td>0.74</td>\n",
-       "      <td>14.66</td>\n",
-       "      <td>4.48</td>\n",
-       "      <td>0.76</td>\n",
+       "      <td>14.53</td>\n",
+       "      <td>4.45</td>\n",
+       "      <td>0.75</td>\n",
        "      <td>0.00</td>\n",
-       "      <td>22.81</td>\n",
-       "      <td>2.28</td>\n",
-       "      <td>36.36</td>\n",
+       "      <td>22.61</td>\n",
+       "      <td>2.26</td>\n",
+       "      <td>36.04</td>\n",
+       "      <td>0.87</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -833,6 +861,7 @@
        "      <td>2.51</td>\n",
        "      <td>1.39</td>\n",
        "      <td>5.89</td>\n",
+       "      <td>0.00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -852,25 +881,27 @@
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>adminregion_mrt</td>\n",
-       "      <td>3.53</td>\n",
-       "      <td>33.58</td>\n",
-       "      <td>15.20</td>\n",
-       "      <td>0.36</td>\n",
-       "      <td>0.19</td>\n",
-       "      <td>1.01</td>\n",
+       "      <td>3.50</td>\n",
+       "      <td>33.28</td>\n",
+       "      <td>15.06</td>\n",
+       "      <td>0.35</td>\n",
+       "      <td>0.18</td>\n",
+       "      <td>1.00</td>\n",
        "      <td>0.13</td>\n",
        "      <td>0.07</td>\n",
-       "      <td>13.74</td>\n",
-       "      <td>7.71</td>\n",
-       "      <td>10.52</td>\n",
-       "      <td>5.84</td>\n",
+       "      <td>13.61</td>\n",
+       "      <td>7.64</td>\n",
+       "      <td>10.43</td>\n",
+       "      <td>5.79</td>\n",
        "      <td>0.10</td>\n",
-       "      <td>1.58</td>\n",
-       "      <td>6.46</td>\n",
+       "      <td>1.57</td>\n",
+       "      <td>6.40</td>\n",
+       "      <td>0.89</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -878,28 +909,28 @@
       ],
       "text/plain": [
        "       location_id  permopen  seasopen  ephopen  saline   lake  seas_lake  \\\n",
-       "0  adminregion_sen     19.13     13.39     3.95    0.03   2.46       0.42   \n",
-       "1  adminregion_gmb     14.05      3.65     0.12    0.00   0.06       0.01   \n",
+       "0  adminregion_sen     19.04     13.33     3.94    0.03   2.45       0.42   \n",
+       "1  adminregion_gmb     13.93      3.62     0.12    0.00   0.06       0.01   \n",
        "2  adminregion_ken      1.92     12.09     3.60   34.78  18.21       0.22   \n",
        "3  adminregion_ssd      0.35      3.61     0.88    0.00   0.52       0.09   \n",
-       "4  adminregion_mrt      3.53     33.58    15.20    0.36   0.19       1.01   \n",
+       "4  adminregion_mrt      3.50     33.28    15.06    0.35   0.18       1.00   \n",
        "\n",
        "   eph_lake  perinuveg  seainuveg  ephinuveg   agri  reservoir  mangrove  \\\n",
-       "0      0.31       1.07      10.16       4.70   6.46       0.56     16.07   \n",
-       "1      0.01       0.74      14.66       4.48   0.76       0.00     22.81   \n",
+       "0      0.31       1.06      10.11       4.67   6.43       0.56     15.99   \n",
+       "1      0.01       0.74      14.53       4.45   0.75       0.00     22.61   \n",
        "2      0.44       0.28       5.58       7.57   4.79       0.73      2.51   \n",
        "3      0.04       1.31      51.30      41.33   0.44       0.13      0.00   \n",
-       "4      0.13       0.07      13.74       7.71  10.52       5.84      0.10   \n",
+       "4      0.13       0.07      13.61       7.64  10.43       5.79      0.10   \n",
        "\n",
-       "   mudflat  shallow  \n",
-       "0     1.98    19.30  \n",
-       "1     2.28    36.36  \n",
-       "2     1.39     5.89  \n",
-       "3     0.00     0.00  \n",
-       "4     1.58     6.46  "
+       "   mudflat  shallow  saltmarsh  \n",
+       "0     1.97    19.21       0.47  \n",
+       "1     2.26    36.04       0.87  \n",
+       "2     1.39     5.89       0.00  \n",
+       "3     0.00     0.00       0.00  \n",
+       "4     1.57     6.40       0.89  "
       ]
      },
-     "execution_count": 40,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -917,7 +948,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 77,
    "id": "d8629c8d",
    "metadata": {},
    "outputs": [
@@ -946,7 +977,7 @@
          "type": "float"
         }
        ],
-       "ref": "c6b99e21-765d-4578-8e0c-4cd340a03ed1",
+       "ref": "3625b749-5782-40dd-baaf-3d9ebabe8abb",
        "rows": [
         [
          "274",
@@ -1026,7 +1057,7 @@
        "248  adminregion_ben    ephinuveg       38.36"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1039,7 +1070,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 78,
    "id": "1e01a7ed",
    "metadata": {},
    "outputs": [
@@ -1048,10 +1079,11 @@
       "text/plain": [
        "array(['agri', 'eph_lake', 'ephinuveg', 'ephopen', 'lake', 'mangrove',\n",
        "       'mudflat', 'perinuveg', 'permopen', 'reservoir', 'saline',\n",
-       "       'seainuveg', 'seas_lake', 'seasopen', 'shallow'], dtype=object)"
+       "       'saltmarsh', 'seainuveg', 'seas_lake', 'seasopen', 'shallow'],\n",
+       "      dtype=object)"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1070,7 +1102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 79,
    "id": "28a139d0",
    "metadata": {},
    "outputs": [
@@ -1162,28 +1194,34 @@
          "name": "shallow",
          "rawType": "float64",
          "type": "float"
+        },
+        {
+         "name": "saltmarsh",
+         "rawType": "float64",
+         "type": "float"
         }
        ],
-       "ref": "fd8db6fb-4978-4608-aeba-e89eb014405e",
+       "ref": "072aa132-1851-443d-bc18-5191e2b02588",
        "rows": [
         [
          "0",
          "wdpa_0",
          "0.66",
-         "4.14",
-         "0.9",
+         "4.13",
+         "0.89",
          "0.0",
-         "0.29",
+         "0.28",
          "0.5",
          "2.15",
          "0.34",
-         "16.85",
-         "28.35",
+         "16.82",
+         "28.31",
          "0.45",
          "0.03",
-         "5.94",
-         "2.16",
-         "37.23"
+         "5.93",
+         "2.15",
+         "37.17",
+         "0.16"
         ],
         [
          "1",
@@ -1198,6 +1236,7 @@
          "0.06",
          "0.48",
          "0.19",
+         "0.0",
          "0.0",
          "0.0",
          "0.0",
@@ -1221,6 +1260,7 @@
          "0.0",
          "0.0",
          "0.0",
+         "0.0",
          "0.0"
         ],
         [
@@ -1237,6 +1277,7 @@
          "1.05",
          "1.63",
          "2.88",
+         "0.0",
          "0.0",
          "0.0",
          "0.0",
@@ -1259,11 +1300,12 @@
          "0.0",
          "0.0",
          "0.0",
+         "0.0",
          "0.0"
         ]
        ],
        "shape": {
-        "columns": 16,
+        "columns": 17,
         "rows": 5
        }
       },
@@ -1302,6 +1344,7 @@
        "      <th>mangrove</th>\n",
        "      <th>mudflat</th>\n",
        "      <th>shallow</th>\n",
+       "      <th>saltmarsh</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -1309,20 +1352,21 @@
        "      <th>0</th>\n",
        "      <td>wdpa_0</td>\n",
        "      <td>0.66</td>\n",
-       "      <td>4.14</td>\n",
-       "      <td>0.90</td>\n",
+       "      <td>4.13</td>\n",
+       "      <td>0.89</td>\n",
        "      <td>0.00</td>\n",
-       "      <td>0.29</td>\n",
+       "      <td>0.28</td>\n",
        "      <td>0.50</td>\n",
        "      <td>2.15</td>\n",
        "      <td>0.34</td>\n",
-       "      <td>16.85</td>\n",
-       "      <td>28.35</td>\n",
+       "      <td>16.82</td>\n",
+       "      <td>28.31</td>\n",
        "      <td>0.45</td>\n",
        "      <td>0.03</td>\n",
-       "      <td>5.94</td>\n",
-       "      <td>2.16</td>\n",
-       "      <td>37.23</td>\n",
+       "      <td>5.93</td>\n",
+       "      <td>2.15</td>\n",
+       "      <td>37.17</td>\n",
+       "      <td>0.16</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -1337,6 +1381,7 @@
        "      <td>0.06</td>\n",
        "      <td>0.48</td>\n",
        "      <td>0.19</td>\n",
+       "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
@@ -1361,6 +1406,7 @@
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -1376,6 +1422,7 @@
        "      <td>1.05</td>\n",
        "      <td>1.63</td>\n",
        "      <td>2.88</td>\n",
+       "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
@@ -1399,6 +1446,7 @@
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1406,28 +1454,28 @@
       ],
       "text/plain": [
        "  location_id  permopen  seasopen  ephopen  saline   lake  seas_lake  \\\n",
-       "0      wdpa_0      0.66      4.14     0.90    0.00   0.29       0.50   \n",
+       "0      wdpa_0      0.66      4.13     0.89    0.00   0.28       0.50   \n",
        "1      wdpa_1      0.02      0.42     0.04   97.94   0.00       0.85   \n",
        "2      wdpa_2      0.52     13.52     0.37   78.53   0.00       0.16   \n",
        "3      wdpa_3      0.33      9.60     0.71    0.00  83.37       0.39   \n",
        "4      wdpa_4      0.71      1.01     0.14   83.23   0.00       0.98   \n",
        "\n",
        "   eph_lake  perinuveg  seainuveg  ephinuveg  agri  reservoir  mangrove  \\\n",
-       "0      2.15       0.34      16.85      28.35  0.45       0.03      5.94   \n",
+       "0      2.15       0.34      16.82      28.31  0.45       0.03      5.93   \n",
        "1      0.00       0.06       0.48       0.19  0.00       0.00      0.00   \n",
        "2      0.09       0.07       4.03       2.68  0.03       0.00      0.00   \n",
        "3      0.00       0.03       1.05       1.63  2.88       0.00      0.00   \n",
        "4      0.00       0.62       5.76       7.41  0.14       0.00      0.00   \n",
        "\n",
-       "   mudflat  shallow  \n",
-       "0     2.16    37.23  \n",
-       "1     0.00     0.00  \n",
-       "2     0.00     0.00  \n",
-       "3     0.00     0.00  \n",
-       "4     0.00     0.00  "
+       "   mudflat  shallow  saltmarsh  \n",
+       "0     2.15    37.17       0.16  \n",
+       "1     0.00     0.00       0.00  \n",
+       "2     0.00     0.00       0.00  \n",
+       "3     0.00     0.00       0.00  \n",
+       "4     0.00     0.00       0.00  "
       ]
      },
-     "execution_count": 50,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1444,7 +1492,7 @@
     "get_wdpa['agri'] = get_wdpa['agri'] + get_wdpa['31'] + get_wdpa['33']\n",
     "get_wdpa['reservoir'] = get_wdpa['reservoir'] + get_wdpa['35'] + get_wdpa['36']\n",
     "\n",
-    "get_wdpa = get_wdpa.drop(columns=['15', '16', '31', '33', '35', '36', 'other'])\n",
+    "get_wdpa = get_wdpa.drop(columns=['15', '16', '31', '33', '35', '36'])\n",
     "\n",
     "get_wdpa['total'] = get_wdpa[wetland_types].sum(axis=1)\n",
     "\n",
@@ -1465,7 +1513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 80,
    "id": "75923f90",
    "metadata": {},
    "outputs": [
@@ -1494,7 +1542,7 @@
          "type": "float"
         }
        ],
-       "ref": "ea94612f-5c7c-4619-8728-56b043fbdd10",
+       "ref": "a498614d-96df-4ec7-89f8-30025a9baa38",
        "rows": [
         [
          "20240",
@@ -1512,19 +1560,19 @@
          "18216",
          "wdpa_0",
          "ephinuveg",
-         "28.35"
+         "28.31"
         ],
         [
          "4048",
          "wdpa_0",
          "ephopen",
-         "0.9"
+         "0.89"
         ],
         [
          "8096",
          "wdpa_0",
          "lake",
-         "0.29"
+         "0.28"
         ]
        ],
        "shape": {
@@ -1573,19 +1621,19 @@
        "      <th>18216</th>\n",
        "      <td>wdpa_0</td>\n",
        "      <td>ephinuveg</td>\n",
-       "      <td>28.35</td>\n",
+       "      <td>28.31</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4048</th>\n",
        "      <td>wdpa_0</td>\n",
        "      <td>ephopen</td>\n",
-       "      <td>0.90</td>\n",
+       "      <td>0.89</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8096</th>\n",
        "      <td>wdpa_0</td>\n",
        "      <td>lake</td>\n",
-       "      <td>0.29</td>\n",
+       "      <td>0.28</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1595,12 +1643,12 @@
        "      location_id wetland_type  percentage\n",
        "20240      wdpa_0         agri        0.45\n",
        "12144      wdpa_0     eph_lake        2.15\n",
-       "18216      wdpa_0    ephinuveg       28.35\n",
-       "4048       wdpa_0      ephopen        0.90\n",
-       "8096       wdpa_0         lake        0.29"
+       "18216      wdpa_0    ephinuveg       28.31\n",
+       "4048       wdpa_0      ephopen        0.89\n",
+       "8096       wdpa_0         lake        0.28"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1621,7 +1669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 81,
    "id": "9bc60217",
    "metadata": {},
    "outputs": [
@@ -1713,9 +1761,14 @@
          "name": "shallow",
          "rawType": "float64",
          "type": "float"
+        },
+        {
+         "name": "saltmarsh",
+         "rawType": "float64",
+         "type": "float"
         }
        ],
-       "ref": "1b9aafb9-5869-47f8-916e-0665f9a351b3",
+       "ref": "94349865-09eb-4b3f-ad19-3efab529d8f4",
        "rows": [
         [
          "0",
@@ -1734,7 +1787,8 @@
          "3.12",
          "2.87",
          "18.17",
-         "35.8"
+         "35.8",
+         "0.0"
         ],
         [
          "1",
@@ -1753,7 +1807,8 @@
          "0.01",
          "1.24",
          "2.21",
-         "9.13"
+         "9.13",
+         "0.0"
         ],
         [
          "2",
@@ -1772,26 +1827,28 @@
          "4.46",
          "0.0",
          "0.0",
+         "0.0",
          "0.0"
         ],
         [
          "3",
          "hydrobasin_tana_basin",
          "2.8",
-         "9.04",
+         "9.03",
          "5.12",
          "0.08",
          "1.07",
          "0.31",
          "0.33",
          "0.63",
-         "11.92",
-         "22.26",
-         "17.54",
+         "11.91",
+         "22.25",
+         "17.53",
          "3.64",
-         "15.41",
+         "15.4",
          "5.26",
-         "4.6"
+         "4.6",
+         "0.03"
         ],
         [
          "4",
@@ -1810,11 +1867,12 @@
          "0.0",
          "0.0",
          "0.0",
+         "0.0",
          "0.0"
         ]
        ],
        "shape": {
-        "columns": 16,
+        "columns": 17,
         "rows": 5
        }
       },
@@ -1853,6 +1911,7 @@
        "      <th>mangrove</th>\n",
        "      <th>mudflat</th>\n",
        "      <th>shallow</th>\n",
+       "      <th>saltmarsh</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -1874,6 +1933,7 @@
        "      <td>2.87</td>\n",
        "      <td>18.17</td>\n",
        "      <td>35.80</td>\n",
+       "      <td>0.00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -1893,6 +1953,7 @@
        "      <td>1.24</td>\n",
        "      <td>2.21</td>\n",
        "      <td>9.13</td>\n",
+       "      <td>0.00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -1912,25 +1973,27 @@
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>hydrobasin_tana_basin</td>\n",
        "      <td>2.80</td>\n",
-       "      <td>9.04</td>\n",
+       "      <td>9.03</td>\n",
        "      <td>5.12</td>\n",
        "      <td>0.08</td>\n",
        "      <td>1.07</td>\n",
        "      <td>0.31</td>\n",
        "      <td>0.33</td>\n",
        "      <td>0.63</td>\n",
-       "      <td>11.92</td>\n",
-       "      <td>22.26</td>\n",
-       "      <td>17.54</td>\n",
+       "      <td>11.91</td>\n",
+       "      <td>22.25</td>\n",
+       "      <td>17.53</td>\n",
        "      <td>3.64</td>\n",
-       "      <td>15.41</td>\n",
+       "      <td>15.40</td>\n",
        "      <td>5.26</td>\n",
        "      <td>4.60</td>\n",
+       "      <td>0.03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -1950,6 +2013,7 @@
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1960,25 +2024,25 @@
        "0         hydrobasin_red_sea_basin      2.68     22.80     4.75    0.05  0.04   \n",
        "1  hydrobasin_horn_of_africa_basin     65.56     20.23     0.84    0.00  0.00   \n",
        "2    hydrobasin_juba_shibeli_basin      3.25     30.08    14.22    0.04  0.05   \n",
-       "3            hydrobasin_tana_basin      2.80      9.04     5.12    0.08  1.07   \n",
+       "3            hydrobasin_tana_basin      2.80      9.03     5.12    0.08  1.07   \n",
        "4           hydrobasin_congo_basin      5.86      1.11     1.14    0.00  0.00   \n",
        "\n",
        "   seas_lake  eph_lake  perinuveg  seainuveg  ephinuveg   agri  reservoir  \\\n",
        "0       3.46      0.28       0.01       3.43       2.43   0.09       3.12   \n",
        "1       0.00      0.02       0.00       0.35       0.40   0.01       0.01   \n",
        "2       0.18      1.47       0.86      14.36      22.65   8.38       4.46   \n",
-       "3       0.31      0.33       0.63      11.92      22.26  17.54       3.64   \n",
+       "3       0.31      0.33       0.63      11.91      22.25  17.53       3.64   \n",
        "4       0.00      0.15       5.76      26.06      59.60   0.32       0.00   \n",
        "\n",
-       "   mangrove  mudflat  shallow  \n",
-       "0      2.87    18.17    35.80  \n",
-       "1      1.24     2.21     9.13  \n",
-       "2      0.00     0.00     0.00  \n",
-       "3     15.41     5.26     4.60  \n",
-       "4      0.00     0.00     0.00  "
+       "   mangrove  mudflat  shallow  saltmarsh  \n",
+       "0      2.87    18.17    35.80       0.00  \n",
+       "1      1.24     2.21     9.13       0.00  \n",
+       "2      0.00     0.00     0.00       0.00  \n",
+       "3     15.40     5.26     4.60       0.03  \n",
+       "4      0.00     0.00     0.00       0.00  "
       ]
      },
-     "execution_count": 58,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1995,7 +2059,7 @@
     "get_hydrobasins['agri'] = get_hydrobasins['agri'] + get_hydrobasins['31'] + get_hydrobasins['33']\n",
     "get_hydrobasins['reservoir'] = get_hydrobasins['reservoir'] + get_hydrobasins['35'] + get_hydrobasins['36']\n",
     "\n",
-    "get_hydrobasins = get_hydrobasins.drop(columns=['15', '16', '31', '33', '35', '36', 'other'])\n",
+    "get_hydrobasins = get_hydrobasins.drop(columns=['15', '16', '31', '33', '35', '36'])\n",
     "\n",
     "get_hydrobasins['total'] = get_hydrobasins[wetland_types].sum(axis=1)\n",
     "get_hydrobasins['basin_name'] = get_hydrobasins['Country'] + ' Basin'\n",
@@ -2017,7 +2081,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 82,
    "id": "b8eee9da",
    "metadata": {},
    "outputs": [
@@ -2046,7 +2110,7 @@
          "type": "float"
         }
        ],
-       "ref": "90e4bb0c-048d-4e42-bdbf-66289669b7e4",
+       "ref": "ac11d74d-ea64-49c9-af72-958a30fe535d",
        "rows": [
         [
          "174",
@@ -2152,7 +2216,7 @@
        "72   hydrobasin_congo_basin         lake        0.00"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2173,7 +2237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 83,
    "id": "4e89f59a",
    "metadata": {},
    "outputs": [
@@ -2265,9 +2329,14 @@
          "name": "shallow",
          "rawType": "float64",
          "type": "float"
+        },
+        {
+         "name": "saltmarsh",
+         "rawType": "float64",
+         "type": "float"
         }
        ],
-       "ref": "6dda7f2f-5472-46d0-ac19-65106a293f7e",
+       "ref": "143cc8bc-ce84-4366-b73f-6eb6aa3b7d3e",
        "rows": [
         [
          "0",
@@ -2280,17 +2349,18 @@
          "1.17",
          "0.11",
          "0.63",
-         "31.65",
+         "31.64",
          "26.0",
          "13.61",
-         "3.3",
+         "3.29",
          "1.02",
          "0.26",
-         "2.54"
+         "2.54",
+         "0.03"
         ]
        ],
        "shape": {
-        "columns": 16,
+        "columns": 17,
         "rows": 1
        }
       },
@@ -2329,6 +2399,7 @@
        "      <th>mangrove</th>\n",
        "      <th>mudflat</th>\n",
        "      <th>shallow</th>\n",
+       "      <th>saltmarsh</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -2343,13 +2414,14 @@
        "      <td>1.17</td>\n",
        "      <td>0.11</td>\n",
        "      <td>0.63</td>\n",
-       "      <td>31.65</td>\n",
+       "      <td>31.64</td>\n",
        "      <td>26.0</td>\n",
        "      <td>13.61</td>\n",
-       "      <td>3.3</td>\n",
+       "      <td>3.29</td>\n",
        "      <td>1.02</td>\n",
        "      <td>0.26</td>\n",
        "      <td>2.54</td>\n",
+       "      <td>0.03</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2360,13 +2432,13 @@
        "0  global_sahel      2.59      8.54     2.84    2.16  3.57       1.17   \n",
        "\n",
        "   eph_lake  perinuveg  seainuveg  ephinuveg   agri  reservoir  mangrove  \\\n",
-       "0      0.11       0.63      31.65       26.0  13.61        3.3      1.02   \n",
+       "0      0.11       0.63      31.64       26.0  13.61       3.29      1.02   \n",
        "\n",
-       "   mudflat  shallow  \n",
-       "0     0.26     2.54  "
+       "   mudflat  shallow  saltmarsh  \n",
+       "0     0.26     2.54       0.03  "
       ]
      },
-     "execution_count": 64,
+     "execution_count": 83,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2383,7 +2455,7 @@
     "get_sahel['agri'] = get_sahel['agri'] + get_sahel['31'] + get_sahel['33']\n",
     "get_sahel['reservoir'] = get_sahel['reservoir'] + get_sahel['35'] + get_sahel['36']\n",
     "\n",
-    "get_sahel = get_sahel.drop(columns=['15', '16', '31', '33', '35', '36', 'other'])\n",
+    "get_sahel = get_sahel.drop(columns=['15', '16', '31', '33', '35', '36'])\n",
     "\n",
     "get_sahel['total'] = get_sahel[wetland_types].sum(axis=1)\n",
     "\n",
@@ -2403,7 +2475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 84,
    "id": "dd957e4c",
    "metadata": {},
    "outputs": [
@@ -2432,7 +2504,7 @@
          "type": "float"
         }
        ],
-       "ref": "aafda2ee-3f87-404b-84e2-caf50a0f8e18",
+       "ref": "b8a0314b-3b8e-4109-a259-966c222ab970",
        "rows": [
         [
          "10",
@@ -2538,7 +2610,7 @@
        "4   global_sahel         lake        3.57"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2551,7 +2623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 85,
    "id": "20a2666b",
    "metadata": {},
    "outputs": [
@@ -2559,10 +2631,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "15\n",
-      "15\n",
-      "15\n",
-      "15\n"
+      "16\n",
+      "16\n",
+      "16\n",
+      "16\n"
      ]
     }
    ],
@@ -2583,7 +2655,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 86,
    "id": "547fbe32",
    "metadata": {},
    "outputs": [],
@@ -2593,7 +2665,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 87,
    "id": "b33eaeca",
    "metadata": {},
    "outputs": [
@@ -2601,7 +2673,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "15\n"
+      "16\n"
      ]
     },
     {
@@ -2609,10 +2681,11 @@
       "text/plain": [
        "array(['agri', 'eph_lake', 'ephinuveg', 'ephopen', 'lake', 'mangrove',\n",
        "       'mudflat', 'perinuveg', 'permopen', 'reservoir', 'saline',\n",
-       "       'seainuveg', 'seas_lake', 'seasopen', 'shallow'], dtype=object)"
+       "       'saltmarsh', 'seainuveg', 'seas_lake', 'seasopen', 'shallow'],\n",
+       "      dtype=object)"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2624,7 +2697,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 88,
    "id": "95f48f84",
    "metadata": {},
    "outputs": [],
@@ -2635,7 +2708,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 90,
    "id": "0a22507e",
    "metadata": {},
    "outputs": [],
@@ -2654,12 +2727,13 @@
     "              'seainuveg': \"#8bc500\",\n",
     "              'seas_lake': \"#4747ff\",\n",
     "              'seasopen': \"#e2ffff\",\n",
-    "              'shallow': \"#ccffdf\",}"
+    "              'shallow': \"#ccffdf\",\n",
+    "              'saltmarsh': \"#a904db\"}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 91,
    "id": "142b4b61",
    "metadata": {},
    "outputs": [],
@@ -2701,7 +2775,8 @@
     "                     'seainuveg':'Seasonally Inundated Vegetation',\n",
     "                     'seas_lake':'Seasonal Lake',\n",
     "                     'seasopen':'Seasonal Open Water',\n",
-    "                     'shallow':'Shallow Coast'\n",
+    "                     'shallow':'Shallow Coast',\n",
+    "                     'saltmarsh':'Salt Marshes'\n",
     "                    }\n",
     "                    }},\n",
     "                }\n",
@@ -2710,7 +2785,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 92,
    "id": "ae523e53",
    "metadata": {},
    "outputs": [
@@ -2835,6 +2910,16 @@
       "    },\n",
       "    {\n",
       "      \"id\": \"wetland_type_adminregion_ben_11\",\n",
+      "      \"label\": \"saltmarsh\",\n",
+      "      \"value\": 0.0,\n",
+      "      \"type\": \"\",\n",
+      "      \"group\": \"\",\n",
+      "      \"color\": \"#a904db\",\n",
+      "      \"format\": \"number\",\n",
+      "      \"unit\": \"%\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"wetland_type_adminregion_ben_12\",\n",
       "      \"label\": \"seainuveg\",\n",
       "      \"value\": 33.48,\n",
       "      \"type\": \"\",\n",
@@ -2844,7 +2929,7 @@
       "      \"unit\": \"%\"\n",
       "    },\n",
       "    {\n",
-      "      \"id\": \"wetland_type_adminregion_ben_12\",\n",
+      "      \"id\": \"wetland_type_adminregion_ben_13\",\n",
       "      \"label\": \"seas_lake\",\n",
       "      \"value\": 1.13,\n",
       "      \"type\": \"\",\n",
@@ -2854,7 +2939,7 @@
       "      \"unit\": \"%\"\n",
       "    },\n",
       "    {\n",
-      "      \"id\": \"wetland_type_adminregion_ben_13\",\n",
+      "      \"id\": \"wetland_type_adminregion_ben_14\",\n",
       "      \"label\": \"seasopen\",\n",
       "      \"value\": 8.81,\n",
       "      \"type\": \"\",\n",
@@ -2864,7 +2949,7 @@
       "      \"unit\": \"%\"\n",
       "    },\n",
       "    {\n",
-      "      \"id\": \"wetland_type_adminregion_ben_14\",\n",
+      "      \"id\": \"wetland_type_adminregion_ben_15\",\n",
       "      \"label\": \"shallow\",\n",
       "      \"value\": 0.0,\n",
       "      \"type\": \"\",\n",
@@ -2891,7 +2976,8 @@
       "        \"seainuveg\": \"Seasonally Inundated Vegetation\",\n",
       "        \"seas_lake\": \"Seasonal Lake\",\n",
       "        \"seasopen\": \"Seasonal Open Water\",\n",
-      "        \"shallow\": \"Shallow Coast\"\n",
+      "        \"shallow\": \"Shallow Coast\",\n",
+      "        \"saltmarsh\": \"Salt Marshes\"\n",
       "      }\n",
       "    }\n",
       "  }\n",
@@ -2913,7 +2999,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 93,
    "id": "48a1254d",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
Update the norebook and seeding data to include two new categories on the Wetlands types indicator: shallow coastal and salt marshes.

This update requires to re-seed **ONLY** the `indicator-data.json`